### PR TITLE
Hotfix/cache results differ

### DIFF
--- a/pipeline/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/Pipeline.java
+++ b/pipeline/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/Pipeline.java
@@ -211,10 +211,11 @@ public final class Pipeline {
 
         if (outputDir != null) {
             logger.info("Writing output.");
+            prevStartTime = System.currentTimeMillis();
             printResultsInFiles(outputDir, name, data, duration);
             var ontoSaveFile = getOntologyOutputFile(outputDir, inputModel.getName());
             ontoConnector.save(ontoSaveFile);
-            logTiming(startTime, "Saving");
+            logTiming(prevStartTime, "Saving");
         }
 
         return data;

--- a/pipeline/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/Pipeline.java
+++ b/pipeline/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/Pipeline.java
@@ -123,7 +123,7 @@ public final class Pipeline {
             return;
         }
 
-        run(name, inputText, inputModel, additionalConfigs, outputDir, providedTextOntology);
+        runAndSave(name, inputText, inputModel, additionalConfigs, outputDir);
     }
 
     private static void printUsage() {
@@ -144,19 +144,38 @@ public final class Pipeline {
                         """);
     }
 
-    public static AgentDatastructure run(String name, File inputText, File inputModel, File additionalConfigs, File outputDir, boolean providedTextOntology) {
-        return run(name, inputText, inputModel, additionalConfigs, outputDir, providedTextOntology, true);
+    /**
+     * Run the approach equally to {@link #runAndSave(String, File, File, File, File, boolean)} but without saving the
+     * output to the file system.
+     *
+     * @param name              Name of the run
+     * @param inputText         File of the input text. Can
+     * @param inputModel        File of the input model (ontology). If inputText is null, needs to contain the text.
+     * @param additionalConfigs File with the additional or overwriting config parameters that should be used
+     * @return the {@link AgentDatastructure} that contains the blackboard with all results (of all steps)
+     */
+    public static AgentDatastructure run(String name, File inputText, File inputModel, File additionalConfigs) {
+        return runAndSave(name, inputText, inputModel, additionalConfigs, null);
     }
 
-    public static AgentDatastructure run(String name, File inputText, File inputModel, File additionalConfigs, File outputDir, boolean providedTextOntology,
-            boolean saveOutput) {
+    /**
+     * Run the approach with the given parameters and save the output to the file system.
+     *
+     * @param name              Name of the run
+     * @param inputText         File of the input text. Can
+     * @param inputModel        File of the input model (ontology). If inputText is null, needs to contain the text.
+     * @param additionalConfigs File with the additional or overwriting config parameters that should be used
+     * @param outputDir         File that represents the output directory where the results should be written to
+     * @return the {@link AgentDatastructure} that contains the blackboard with all results (of all steps)
+     */
+    public static AgentDatastructure runAndSave(String name, File inputText, File inputModel, File additionalConfigs, File outputDir) {
         long startTime = System.currentTimeMillis();
         long prevStartTime = System.currentTimeMillis();
 
         var ontoConnector = new OntologyConnector(inputModel.getAbsolutePath());
 
         logger.info("Preparing and processing text input.");
-        IText annotatedText = getAnnotatedText(inputText, providedTextOntology, ontoConnector);
+        IText annotatedText = getAnnotatedText(inputText, ontoConnector);
         if (annotatedText == null) {
             logger.info("Could not preprocess or receive annotated text. Exiting.");
             return null;
@@ -164,7 +183,9 @@ public final class Pipeline {
 
         logger.info("Processing model input");
         IModelConnector pcmModel = new PcmOntologyModelConnector(ontoConnector);
-        FilePrinter.writeModelInstancesInCsvFile(Path.of(outputDir.getAbsolutePath(), name + "-instances.csv").toFile(), runModelExtractor(pcmModel), name);
+        if (outputDir != null) {
+            FilePrinter.writeModelInstancesInCsvFile(Path.of(outputDir.getAbsolutePath(), name + "-instances.csv").toFile(), runModelExtractor(pcmModel), name);
+        }
 
         logTiming(prevStartTime, "Text- and Model-Loading");
 
@@ -187,13 +208,15 @@ public final class Pipeline {
 
         var duration = Duration.ofMillis(System.currentTimeMillis() - startTime);
         logger.info("Finished in {}.{}s.", duration.getSeconds(), duration.toMillisPart());
-        if (saveOutput) {
+
+        if (outputDir != null) {
             logger.info("Writing output.");
             printResultsInFiles(outputDir, name, data, duration);
             var ontoSaveFile = getOntologyOutputFile(outputDir, inputModel.getName());
             ontoConnector.save(ontoSaveFile);
             logTiming(startTime, "Saving");
         }
+
         return data;
     }
 
@@ -203,11 +226,11 @@ public final class Pipeline {
         logger.info("Finished step {} in {}.{}s.", step, duration.getSeconds(), duration.toMillisPart());
     }
 
-    private static IText getAnnotatedText(File inputText, boolean providedTextOntology, OntologyConnector ontoConnector) {
+    private static IText getAnnotatedText(File inputText, OntologyConnector ontoConnector) {
         var ontologyTextProvider = OntologyTextProvider.get(ontoConnector);
 
         IText annotatedText = null;
-        if (!providedTextOntology) {
+        if (inputText != null) {
             try {
                 ITextConnector textConnector = new ParseProvider(new FileInputStream(inputText));
                 annotatedText = textConnector.getAnnotatedText();

--- a/pipeline/src/main/resources/configs/Pipeline.properties
+++ b/pipeline/src/main/resources/configs/Pipeline.properties
@@ -1,5 +1,1 @@
-documentation_Path = /texts/EcsaText.txt
-testDocumentation_Path = /texts/TestText.txt
-fileForInput_Path = /texts/InstanceEvaluation_Sentences.txt
-fileForResults_Path = evaluations/InstanceEvaluation.txt
-fileForCSVResults_Path = ecsaEvaluations/
+# empty

--- a/pipeline/src/main/resources/log4j.xml
+++ b/pipeline/src/main/resources/log4j.xml
@@ -13,7 +13,7 @@
 		<level value="error" />
 		<appender-ref ref="console" />
 	</logger>
-		<root>
+	<root>
 		<priority value="info" />
 		<appender-ref ref="console" />
 	</root>

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/EvaluationResults.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/EvaluationResults.java
@@ -1,5 +1,8 @@
 package edu.kit.kastel.mcse.ardoco.core.tests;
 
+import java.util.Locale;
+import java.util.Objects;
+
 class EvaluationResults {
     public double precision;
     public double recall;
@@ -22,6 +25,34 @@ class EvaluationResults {
 
     public double getF1() {
         return f1;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(Locale.US, "Precision: %.3f\tRecall: %.3f\tF1: %.3f", precision, recall, f1);
+    }
+
+    public String toPrettyString() {
+        return String.format(Locale.US, "\tPrecision:\t%.3f%n\tRecall:\t\t%.3f%n\tF1:\t\t%.3f", precision, recall, f1);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(f1, precision, recall);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof EvaluationResults)) {
+            return false;
+        }
+        EvaluationResults other = (EvaluationResults) obj;
+        return Double.doubleToLongBits(f1) == Double.doubleToLongBits(other.f1)
+                && Double.doubleToLongBits(precision) == Double.doubleToLongBits(other.precision)
+                && Double.doubleToLongBits(recall) == Double.doubleToLongBits(other.recall);
     }
 
 }

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/PerformanceIT.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/PerformanceIT.java
@@ -23,7 +23,6 @@ class PerformanceIT {
     private File additionalConfigs = null;
     private File outputDir = new File(OUTPUT);
     private String name = "teammates";
-    private boolean useOntology = true;
 
     @Disabled("Only for individual testing, not for CI")
     @Test
@@ -63,7 +62,7 @@ class PerformanceIT {
 
     private Duration measureExecution() {
         Instant start = Instant.now();
-        Pipeline.run("test_time_" + name, inputText, inputModel, additionalConfigs, outputDir, useOntology, false);
+        Pipeline.runAndSave("test_time_" + name, inputText, inputModel, additionalConfigs, outputDir);
         Instant end = Instant.now();
 
         var duration = Duration.between(start, end);
@@ -75,7 +74,6 @@ class PerformanceIT {
         inputText = null;
         var inputFilePath = String.format("src/test/resources/%s/%s_w_text.owl", name, name);
         inputModel = new File(inputFilePath);
-        useOntology = true;
     }
 
     private void prepareText() {
@@ -83,8 +81,6 @@ class PerformanceIT {
         inputText = new File(inputTextPath);
         var inputFilePath = String.format("src/test/resources/%s/%s.owl", name, name);
         inputModel = new File(inputFilePath);
-
-        useOntology = false;
     }
 
 }

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/TracelinksIT.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/TracelinksIT.java
@@ -41,7 +41,6 @@ class TracelinksIT {
         config.delete();
     }
 
-    @Disabled("Disabled for now")
     @Test
     @DisplayName("Evaluate Teastore")
     void compareTracelinksTeastoreIT() {
@@ -53,7 +52,6 @@ class TracelinksIT {
         compareOntologyBased("teastore", similarity, minPrecision, minRecall, minF1);
     }
 
-    @Disabled("Disabled for now")
     @Test
     @DisplayName("Evaluate Teammates")
     void compareTracelinksTeammatesIT() {
@@ -65,7 +63,6 @@ class TracelinksIT {
         compareOntologyBased("teammates", similarity, minPrecision, minRecall, minF1);
     }
 
-    @Disabled("Disabled for now")
     @Test
     @DisplayName("Evaluate Mediastore")
     void compareTracelinksMediastoreIT() {
@@ -77,11 +74,7 @@ class TracelinksIT {
         compareOntologyBased("mediastore", similarity, minPrecision, minRecall, minF1);
     }
 
-    // TODO weird phenomenon: When using caching, for teammates, the recall drops but the precision increases to overall
-    // better F1
-    // w/o caching: 0.6827, 0.8875, 0.7717
-    // w caching: 0.8250, 0.8250, 0.8250
-    // @Disabled
+    @Disabled("Disabled for CI. Only enable this locally if you want to test the cache.")
     @DisplayName("Compare cached and non-cached evaluation")
     @ParameterizedTest
     @ValueSource(strings = { "mediastore", "teastore", "teammates" })

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/TracelinksIT.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/TracelinksIT.java
@@ -13,11 +13,18 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.collections.api.factory.Lists;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
 
+import edu.kit.kastel.mcse.ardoco.core.datastructures.agents.AgentDatastructure;
 import edu.kit.kastel.mcse.ardoco.core.datastructures.definitions.IConnectionState;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.Pipeline;
+import edu.kit.kastel.mcse.ardoco.core.text.providers.ontology.OntologyTextProvider;
 
 class TracelinksIT {
     private static final Logger logger = LogManager.getLogger(TracelinksIT.class);
@@ -36,6 +43,7 @@ class TracelinksIT {
         config.delete();
     }
 
+    @Disabled("Disabled for now")
     @Test
     @DisplayName("Evaluate Teastore")
     void compareTracelinksTeastoreIT() {
@@ -47,10 +55,7 @@ class TracelinksIT {
         compareOntologyBased("teastore", similarity, minPrecision, minRecall, minF1);
     }
 
-    // TODO weird phenomenon: When using caching, the recall drops but the precision increases to overall better F1
-    // w/o caching: 0.6827, 0.8875, 0.7717
-    // w caching: 0.8250, 0.8250, 0.8250
-    // Note: There is the warning that there is a change in the OntologyConnector (for OntologyWord)
+    @Disabled("Disabled for now")
     @Test
     @DisplayName("Evaluate Teammates")
     void compareTracelinksTeammatesIT() {
@@ -62,6 +67,7 @@ class TracelinksIT {
         compareOntologyBased("teammates", similarity, minPrecision, minRecall, minF1);
     }
 
+    @Disabled("Disabled for now")
     @Test
     @DisplayName("Evaluate Mediastore")
     void compareTracelinksMediastoreIT() {
@@ -71,6 +77,45 @@ class TracelinksIT {
         var minF1 = 0.52d;
 
         compareOntologyBased("mediastore", similarity, minPrecision, minRecall, minF1);
+    }
+
+    // TODO weird phenomenon: When using caching, for teammates, the recall drops but the precision increases to overall
+    // better F1
+    // w/o caching: 0.6827, 0.8875, 0.7717
+    // w caching: 0.8250, 0.8250, 0.8250
+    // @Disabled
+    @DisplayName("Compare cached and non-cached evaluation")
+    @ParameterizedTest
+    @ValueSource(strings = { "teammates" })
+    void compareCachingResultsIT(String name) {
+        // set up
+        var similarity = 1.0;
+        if (name.equals("teammates")) {
+            similarity = 0.8;
+        }
+        prepareConfig(similarity);
+
+        var inputFilePath = String.format("src/test/resources/%s/%s_w_text.owl", name, name);
+        inputModel = new File(inputFilePath);
+
+        var runName = "test_" + name;
+
+        // run cached
+        OntologyTextProvider.enableCache(true);
+        var dataCached = Pipeline.run(runName + "_cached", inputText, inputModel, additionalConfigs, outputDir, true, false);
+        Assertions.assertNotNull(dataCached);
+        var resultsCached = calculateResults(name, dataCached);
+        logger.info("Cached results for {}:\n{}", name, resultsCached.toPrettyString());
+
+        // run not cached
+        OntologyTextProvider.enableCache(false);
+        var dataNonCached = Pipeline.run(runName, inputText, inputModel, additionalConfigs, outputDir, true, false);
+        Assertions.assertNotNull(dataNonCached);
+        var resultsNonCached = calculateResults(name, dataNonCached);
+        logger.info("Non-cached results for {}:\n{}", name, resultsNonCached.toPrettyString());
+
+        Assertions.assertEquals(resultsCached, resultsNonCached, "Results for cached and non-cached run are not equal");
+
     }
 
     private void compareOntologyBased(String name, double similarity, double minPrecision, double minRecall, double minF1) {
@@ -96,23 +141,28 @@ class TracelinksIT {
         var data = Pipeline.run("test_" + name, inputText, inputModel, additionalConfigs, outputDir, useTextOntology, false);
         Assertions.assertNotNull(data);
 
+        var results = calculateResults(name, data);
+        double precision = results.getPrecision();
+        double recall = results.getRecall();
+        double f1 = results.getF1();
+
+        if (logger.isInfoEnabled()) {
+            logger.info("\n{} with similarity {}:\n{}", name, similarity, results.toPrettyString());
+        }
+
+        Assertions.assertTrue(precision >= minPrecision, "Precision " + precision + " is below the expected minimum value " + minPrecision);
+        Assertions.assertTrue(recall >= minRecall, "Recall " + recall + " is below the expected minimum value " + minRecall);
+        Assertions.assertTrue(f1 >= minF1, "F1 " + f1 + " is below the expected minimum value " + minF1);
+    }
+
+    private EvaluationResults calculateResults(String name, AgentDatastructure data) {
         var connectionState = data.getConnectionState();
         List<String> traceLinks = getTraceLinksFromConnectionState(connectionState);
 
         var goldStandard = getGoldStandard(name);
 
         var results = EvalUtil.compare(traceLinks, goldStandard);
-        double precision = results.getPrecision();
-        double recall = results.getRecall();
-        double f1 = results.getF1();
-
-        if (logger.isInfoEnabled()) {
-            logger.info("\n{} with similarity {}:\n\tPrecision: {}\n\tRecall: {}\n\tF1: {}", name, similarity, precision, recall, f1);
-        }
-
-        Assertions.assertTrue(precision >= minPrecision, "Precision " + precision + " is below the expected minimum value " + minPrecision);
-        Assertions.assertTrue(recall >= minRecall, "Recall " + recall + " is below the expected minimum value " + minRecall);
-        Assertions.assertTrue(f1 >= minF1, "F1 " + f1 + " is below the expected minimum value " + minF1);
+        return results;
     }
 
     private List<String> getTraceLinksFromConnectionState(IConnectionState connectionState) {

--- a/text-extractor/src/main/java/edu/kit/kastel/mcse/ardoco/core/datastructures/NounMapping.java
+++ b/text-extractor/src/main/java/edu/kit/kastel/mcse/ardoco/core/datastructures/NounMapping.java
@@ -49,16 +49,9 @@ public class NounMapping implements INounMapping {
 
         this.distribution = new EnumMap<>(distribution);
 
-        if (!distribution.containsKey(MappingKind.NAME)) {
-            this.distribution.put(MappingKind.NAME, 0.0);
-        }
-        if (!distribution.containsKey(MappingKind.TYPE)) {
-            this.distribution.put(MappingKind.TYPE, 0.0);
-        }
-        if (!distribution.containsKey(MappingKind.NAME_OR_TYPE)) {
-            this.distribution.put(MappingKind.NAME_OR_TYPE, 0.0);
-        }
-
+        this.distribution.putIfAbsent(MappingKind.NAME, 0.0);
+        this.distribution.putIfAbsent(MappingKind.TYPE, 0.0);
+        this.distribution.putIfAbsent(MappingKind.NAME_OR_TYPE, 0.0);
     }
 
     /**
@@ -345,8 +338,8 @@ public class NounMapping implements INounMapping {
             highestProbability = newProbability;
             distribution.put(mostProbableKind, newProbability);
         } else if (highestProbability >= newProbability) {
-            double porbabilityToSet = highestProbability + newProbability * (1 - highestProbability);
-            recalculateProbability(mostProbableKind, porbabilityToSet);
+            double probabilityToSet = highestProbability + newProbability * (1 - highestProbability);
+            recalculateProbability(mostProbableKind, probabilityToSet);
         } else {
             double porbabilityToSet = (highestProbability + newProbability) * 0.5;
             recalculateProbability(mostProbableKind, porbabilityToSet);

--- a/text-extractor/src/main/java/edu/kit/kastel/mcse/ardoco/core/datastructures/TextState.java
+++ b/text-extractor/src/main/java/edu/kit/kastel/mcse/ardoco/core/datastructures/TextState.java
@@ -22,6 +22,8 @@ import edu.kit.kastel.mcse.ardoco.core.util.Utilis;
  * The Class TextState defines the basic implementation of a {@link ITextState}.
  */
 public class TextState implements ITextState {
+    private static final double DELTA = 0.0001;
+
     private double similarityPercentage;
 
     private Map<String, NounMapping> nounMappings;
@@ -513,7 +515,7 @@ public class TextState implements ITextState {
      */
     @Override
     public final boolean isNodeContainedByNounMappings(IWord node) {
-        return !nounMappings.values().stream().filter(n -> n.getWords().contains(node)).findAny().isEmpty();
+        return nounMappings.values().stream().anyMatch(n -> n.getWords().contains(node));
     }
 
     /**
@@ -524,7 +526,7 @@ public class TextState implements ITextState {
      */
     @Override
     public final boolean isNodeContainedByTypeNodes(IWord node) {
-        return !nounMappings.values().stream().filter(n -> MappingKind.TYPE == n.getKind()).filter(n -> n.getWords().contains(node)).findAny().isEmpty();
+        return nounMappings.values().stream().anyMatch(n -> MappingKind.TYPE == n.getKind() && n.getWords().contains(node));
     }
 
     @Override

--- a/text-extractor/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextractor/agents/MultiplePartAgent.java
+++ b/text-extractor/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextractor/agents/MultiplePartAgent.java
@@ -60,7 +60,9 @@ public class MultiplePartAgent extends TextAgent {
             ImmutableList<IWord> nameNodes = Lists.immutable.withAll(nameMap.getWords());
             for (IWord n : nameNodes) {
                 IWord pre = n.getPreWord();
-                if (pre != null && textState.isNodeContainedByNounMappings(pre) && !textState.isNodeContainedByTypeNodes(pre)) {
+                boolean nodeIsContainedByNounMappings = textState.isNodeContainedByNounMappings(pre);
+                boolean nodeIsContainedByTypeNodes = textState.isNodeContainedByTypeNodes(pre);
+                if (pre != null && nodeIsContainedByNounMappings && !nodeIsContainedByTypeNodes) {
                     String ref = pre.getText() + " " + n.getText();
                     addTerm(ref, pre, n, MappingKind.NAME);
                 }
@@ -73,7 +75,9 @@ public class MultiplePartAgent extends TextAgent {
             ImmutableList<IWord> typeNodes = Lists.immutable.withAll(typeMap.getWords());
             for (IWord n : typeNodes) {
                 IWord pre = n.getPreWord();
-                if (pre != null && textState.isNodeContainedByNounMappings(pre) && !textState.isNodeContainedByNameNodes(pre)) {
+                boolean nodeIsContainedByNounMappings = textState.isNodeContainedByNounMappings(pre);
+                boolean nodeIsContainedByNameNodes = textState.isNodeContainedByNameNodes(pre);
+                if (pre != null && nodeIsContainedByNounMappings && !nodeIsContainedByNameNodes) {
                     String ref = pre.getText() + " " + n.getText();
                     addTerm(ref, pre, n, MappingKind.TYPE);
                 }
@@ -82,7 +86,6 @@ public class MultiplePartAgent extends TextAgent {
     }
 
     private void addTerm(String ref, IWord pre, IWord n, MappingKind kind) {
-
         ImmutableList<INounMapping> preMappings = textState.getNounMappingsByNode(pre);
         ImmutableList<INounMapping> nMappings = textState.getNounMappingsByNode(n);
 

--- a/text-extractor/src/main/resources/configs/TextExtractor.properties
+++ b/text-extractor/src/main/resources/configs/TextExtractor.properties
@@ -1,4 +1,4 @@
 
 Text_Agents = InitialTextAgent MultiplePartAgent
 
-similarityPercentage = 0.75
+similarityPercentage = 1.00

--- a/text-provider-stanford/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/indirect/ParseConverter.java
+++ b/text-provider-stanford/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/indirect/ParseConverter.java
@@ -3,6 +3,7 @@ package edu.kit.kastel.mcse.ardoco.core.text.providers.indirect;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.eclipse.collections.api.factory.Lists;
@@ -126,7 +127,7 @@ public class ParseConverter {
             sentence = Integer.valueOf(String.valueOf(node.getAttributeValue("sentenceNumber")));
         }
 
-        private POSTag getPosTag(INode node) {
+        private static POSTag getPosTag(INode node) {
             var posTagValue = String.valueOf(node.getAttributeValue("pos"));
             return POSTag.get(posTagValue);
         }
@@ -180,6 +181,26 @@ public class ParseConverter {
                 return null;
             }
             return parent.getWords().get(position + 1);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(position, sentence, text);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Word other = (Word) obj;
+            return position == other.position && sentence == other.sentence && Objects.equals(text, other.text);
         }
     }
 

--- a/text-provider/pom.xml
+++ b/text-provider/pom.xml
@@ -15,6 +15,12 @@
 		<groupId>edu.kit.kastel.mcse.ardoco</groupId>
 		<artifactId>ontology-connector</artifactId>
 	</dependency>
+	
+	<dependency>
+		<groupId>org.junit.jupiter</groupId>
+		<artifactId>junit-jupiter-params</artifactId>
+		<version>5.7.2</version>
+	</dependency>
   </dependencies>
 
 </project>

--- a/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/CachedOntologyText.java
+++ b/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/CachedOntologyText.java
@@ -1,5 +1,6 @@
 package edu.kit.kastel.mcse.ardoco.core.text.providers.ontology;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.jena.ontology.Individual;
@@ -82,5 +83,25 @@ public class CachedOntologyText implements IText {
     public void setDirty() {
         textList = null;
         words = null;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ontologyText);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        CachedOntologyText other = (CachedOntologyText) obj;
+        return Objects.equals(ontologyText, other.ontologyText);
     }
 }

--- a/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/CachedOntologyText.java
+++ b/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/CachedOntologyText.java
@@ -47,7 +47,7 @@ public class CachedOntologyText implements IText {
 
     @Override
     public IWord getFirstWord() {
-        return ontologyText.getFirstWord();
+        return new CachedOntologyWord(ontologyText.getFirstWord());
     }
 
     @Override

--- a/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/CachedOntologyWord.java
+++ b/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/CachedOntologyWord.java
@@ -1,6 +1,7 @@
 package edu.kit.kastel.mcse.ardoco.core.text.providers.ontology;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.ImmutableList;
@@ -103,6 +104,26 @@ public class CachedOntologyWord implements IWord {
         lemma = null;
         outDependencies = Maps.mutable.empty();
         inDependencies = Maps.mutable.empty();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getPosition(), getSentenceNo(), getText());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        CachedOntologyWord other = (CachedOntologyWord) obj;
+        return getPosition() == other.getPosition() && getSentenceNo() == other.getSentenceNo() && Objects.equals(getText(), other.getText());
     }
 
 }

--- a/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/CachedOntologyWord.java
+++ b/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/CachedOntologyWord.java
@@ -12,7 +12,7 @@ import edu.kit.kastel.mcse.ardoco.core.datastructures.definitions.POSTag;
 
 public class CachedOntologyWord implements IWord {
 
-    private OntologyWord ontologyWord;
+    private IWord ontologyWord;
 
     private int sentenceNo = -1;
     private String text = null;
@@ -24,7 +24,10 @@ public class CachedOntologyWord implements IWord {
     private Map<DependencyTag, ImmutableList<IWord>> outDependencies = Maps.mutable.empty();
     private Map<DependencyTag, ImmutableList<IWord>> inDependencies = Maps.mutable.empty();
 
-    protected CachedOntologyWord(OntologyWord ontologyWord) {
+    protected CachedOntologyWord(IWord ontologyWord) {
+        if (ontologyWord == null) {
+            throw new IllegalArgumentException("Word cannot be null");
+        }
         this.ontologyWord = ontologyWord;
     }
 
@@ -55,7 +58,11 @@ public class CachedOntologyWord implements IWord {
     @Override
     public synchronized IWord getPreWord() {
         if (preWord == null) {
-            preWord = ontologyWord.getPreWord();
+            var newPreWord = ontologyWord.getPreWord();
+            if (newPreWord == null) {
+                return null;
+            }
+            preWord = new CachedOntologyWord(newPreWord);
         }
         return preWord;
     }
@@ -63,7 +70,11 @@ public class CachedOntologyWord implements IWord {
     @Override
     public synchronized IWord getNextWord() {
         if (nextWord == null) {
-            nextWord = ontologyWord.getNextWord();
+            var newNextWord = ontologyWord.getNextWord();
+            if (newNextWord == null) {
+                return null;
+            }
+            nextWord = new CachedOntologyWord(newNextWord);
         }
         return nextWord;
     }
@@ -86,12 +97,12 @@ public class CachedOntologyWord implements IWord {
 
     @Override
     public synchronized ImmutableList<IWord> getWordsThatAreDependencyOfThis(DependencyTag dependencyTag) {
-        return inDependencies.computeIfAbsent(dependencyTag, dt -> ontologyWord.getWordsThatAreDependencyOfThis(dt));
+        return inDependencies.computeIfAbsent(dependencyTag, dt -> ontologyWord.getWordsThatAreDependencyOfThis(dt).collect(CachedOntologyWord::new));
     }
 
     @Override
     public synchronized ImmutableList<IWord> getWordsThatAreDependentOnThis(DependencyTag dependencyTag) {
-        return outDependencies.computeIfAbsent(dependencyTag, dt -> ontologyWord.getWordsThatAreDependentOnThis(dt));
+        return outDependencies.computeIfAbsent(dependencyTag, dt -> ontologyWord.getWordsThatAreDependentOnThis(dt).collect(CachedOntologyWord::new));
     }
 
     public void setDirty() {
@@ -116,10 +127,7 @@ public class CachedOntologyWord implements IWord {
         if (this == obj) {
             return true;
         }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
         CachedOntologyWord other = (CachedOntologyWord) obj;

--- a/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/CachedOntologyWord.java
+++ b/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/CachedOntologyWord.java
@@ -1,7 +1,6 @@
 package edu.kit.kastel.mcse.ardoco.core.text.providers.ontology;
 
 import java.util.Map;
-import java.util.Objects;
 
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.ImmutableList;
@@ -108,7 +107,13 @@ public class CachedOntologyWord implements IWord {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getPosition(), getSentenceNo(), getText());
+        final var prime = 31;
+        var result = 1;
+        result = prime * result + getPosition();
+        result = prime * result + getSentenceNo();
+        var thisText = getText();
+        result = prime * result + ((thisText == null) ? 0 : thisText.hashCode());
+        return result;
     }
 
     @Override
@@ -123,7 +128,24 @@ public class CachedOntologyWord implements IWord {
             return false;
         }
         CachedOntologyWord other = (CachedOntologyWord) obj;
-        return getPosition() == other.getPosition() && getSentenceNo() == other.getSentenceNo() && Objects.equals(getText(), other.getText());
+        if (getPosition() != other.getPosition()) {
+            return false;
+        }
+
+        if (getSentenceNo() != other.getSentenceNo()) {
+            return false;
+        }
+        var thisText = getText();
+        var otherText = other.getText();
+        if (thisText == null) {
+            if (otherText != null) {
+                return false;
+            }
+        } else if (!thisText.equals(otherText)) {
+            return false;
+        }
+
+        return true;
     }
 
 }

--- a/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/CommonOntologyUris.java
+++ b/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/CommonOntologyUris.java
@@ -1,0 +1,35 @@
+package edu.kit.kastel.mcse.ardoco.core.text.providers.ontology;
+
+enum CommonOntologyUris {
+
+    TEXT_PROPERTY("https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLDataProperty_2abdbab4_07a1_44e4_86b4_1dd2db60d093"),
+    POS_PROPERTY("https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLDataProperty_4a42b4d3_f585_4d3a_ac8d_12efcd2f41ed"),
+    LEMMA_PROPERTY("https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLDataProperty_8641228e_89c1_4094_8770_d6db4cff934d"),
+    POSITION_PROPERTY("https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLDataProperty_24a1fab1_8d82_4a64_a569_26181935ae92"),
+    SENTENCE_PROPERTY("https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLDataProperty_cca1bf08_930a_4c38_b1b4_4b127db235a3"),
+    HAS_ITEM_PROPERTY("https://informalin.github.io/knowledgebases/external/olo/orderedlistontology.owl#item"),
+    HAS_NEXT_PROPERTY("https://informalin.github.io/knowledgebases/external/olo/orderedlistontology.owl#next"),
+    HAS_PREVIOUS_PROPERTY("https://informalin.github.io/knowledgebases/external/olo/orderedlistontology.owl#previous"),
+    DEP_SOURCE_PROPERTY("https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLObjectProperty_338dfb91_e78b_4145_bf8c_a952e927b6e9"),
+    DEP_TARGET_PROPERTY("https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLObjectProperty_82e64c17_5998_4d50_941f_a2b859c1a95b"),
+    DEP_TYPE_PROPERTY("https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLAnnotationProperty_79e191d9_7e85_461e_ae42_62df5078719b"),
+    HAS_WORDS_PROPERTY("https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLObjectProperty_8acb94df_fd3f_4535_bd65_f43bc50f7c8d"),
+    UUID_PROPERTY("https://informalin.github.io/knowledgebases/informalin_base.owl#OWLDataProperty_d45dcc42_a463_476d_a06f_939637c6bc1c"),
+    TEXT_DOCUMENT_CLASS("https://informalin.github.io/knowledgebases/informalin_base_text#OWLClass_f7ee71e0_fe7c_4640_b432_bb876416974a"),
+    WORD_CLASS("https://informalin.github.io/knowledgebases/informalin_base#OWLClass_33cd62aa_e856_4bd3_93fd_454951b453b0"),
+    WORD_DEPENDENCY_CLASS("https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLClass_23b11e6d_0c9d_48a6_98c6_27ce9f2ceffb");
+
+    private String uri;
+
+    CommonOntologyUris(String uri) {
+        this.uri = uri;
+    }
+
+    /**
+     * @return the uri
+     */
+    public String getUri() {
+        return uri;
+    }
+
+}

--- a/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/OntologyText.java
+++ b/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/OntologyText.java
@@ -1,5 +1,6 @@
 package edu.kit.kastel.mcse.ardoco.core.text.providers.ontology;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.jena.ontology.Individual;
@@ -102,6 +103,26 @@ public class OntologyText implements IText {
             throw new IllegalStateException(ERR_NO_LIST);
         }
         return textOloOpt.get();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(textIndividual.getURI());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        OntologyText other = (OntologyText) obj;
+        return Objects.equals(textIndividual.getURI(), other.textIndividual.getURI());
     }
 
 }

--- a/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/OntologyText.java
+++ b/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/OntologyText.java
@@ -3,7 +3,8 @@ package edu.kit.kastel.mcse.ardoco.core.text.providers.ontology;
 import java.util.Optional;
 
 import org.apache.jena.ontology.Individual;
-import org.apache.jena.ontology.ObjectProperty;
+import org.apache.jena.ontology.OntClass;
+import org.apache.jena.ontology.OntProperty;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
@@ -21,7 +22,8 @@ public class OntologyText implements IText {
     private OntologyConnector ontologyConnector;
     private Individual textIndividual;
 
-    private ObjectProperty wordsProperty;
+    private OntProperty wordsProperty;
+    private static OntClass textDocumentClass = null;
 
     protected OntologyText(OntologyConnector ontologyConnector, Individual textIndividual) {
         this.ontologyConnector = ontologyConnector;
@@ -35,6 +37,10 @@ public class OntologyText implements IText {
     }
 
     protected static OntologyText get(OntologyConnector ontologyConnector) {
+        if (textDocumentClass == null) {
+            textDocumentClass = ontologyConnector.getClassByIri(CommonOntologyUris.TEXT_DOCUMENT_CLASS.getUri()).orElseThrow();
+        }
+
         var optText = getTextIndividual(ontologyConnector);
         if (optText.isEmpty()) {
             throw new IllegalStateException(ERR_NO_TEXT_FOUND);
@@ -45,7 +51,7 @@ public class OntologyText implements IText {
     }
 
     protected static Optional<Individual> getTextIndividual(OntologyInterface ontologyConnector) {
-        var textIndividuals = ontologyConnector.getIndividualsOfClass("TextDocument");
+        var textIndividuals = ontologyConnector.getIndividualsOfClass(textDocumentClass);
         if (textIndividuals.isEmpty()) {
             return Optional.empty();
         } else {
@@ -55,7 +61,7 @@ public class OntologyText implements IText {
     }
 
     private void init() {
-        wordsProperty = ontologyConnector.getObjectProperty("has words").orElseThrow();
+        wordsProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.HAS_WORDS_PROPERTY.getUri()).orElseThrow();
     }
 
     @Override

--- a/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/OntologyTextProvider.java
+++ b/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/OntologyTextProvider.java
@@ -7,6 +7,7 @@ import org.apache.jena.ontology.Individual;
 import org.apache.jena.ontology.OntClass;
 import org.apache.jena.ontology.OntProperty;
 import org.apache.jena.vocabulary.XSD;
+import org.eclipse.collections.api.list.ImmutableList;
 
 import edu.kit.kastel.mcse.ardoco.core.datastructures.definitions.DependencyTag;
 import edu.kit.kastel.mcse.ardoco.core.datastructures.definitions.IText;
@@ -91,10 +92,12 @@ public final class OntologyTextProvider implements ITextConnector {
         var uuid = ontologyConnector.getLocalName(textIndividual);
         ontologyConnector.addPropertyToIndividual(textIndividual, uuidProperty, uuid);
 
-        // add word individuals
+        ImmutableList<IWord> words = text.getWords();
+
+        // first add all word individuals
         var wordIndividuals = new ArrayList<Individual>();
         var wordsToIndividuals = new HashMap<IWord, Individual>();
-        for (var word : text.getWords()) {
+        for (var word : words) {
             var wordIndividual = addWord(word);
             wordIndividuals.add(wordIndividual);
             wordsToIndividuals.put(word, wordIndividual);
@@ -102,7 +105,7 @@ public final class OntologyTextProvider implements ITextConnector {
 
         // add dependencies to words.
         // We only add outgoing dependencies as ingoing are the same (but viewed from another perspective)
-        for (var word : text.getWords()) {
+        for (var word : words) {
             var wordIndividual = wordsToIndividuals.get(word);
             for (var dependencyType : DependencyTag.values()) {
                 var outDependencies = word.getWordsThatAreDependencyOfThis(dependencyType);

--- a/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/OntologyTextProvider.java
+++ b/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/OntologyTextProvider.java
@@ -19,7 +19,7 @@ import edu.kit.kastel.mcse.ardoco.core.text.providers.ITextConnector;
 public class OntologyTextProvider implements ITextConnector {
     private static final String TEXT_ONTOLOGY_IRI = "https://informalin.github.io/knowledgebases/informalin_base_text.owl";
 
-    private static final boolean USE_CACHED = false;
+    private static boolean useCache = true;
 
     private OntologyConnector ontologyConnector;
 
@@ -58,6 +58,16 @@ public class OntologyTextProvider implements ITextConnector {
         return otp;
     }
 
+    /**
+     * Sets whether there should be caching used for the annotated text. Does not change the caching for previously
+     * returned annotated texts, only for future ones!
+     *
+     * @param useCache if caching should be used for the annotated text
+     */
+    public static void enableCache(boolean useCache) {
+        OntologyTextProvider.useCache = useCache;
+    }
+
     private void init() {
         ontologyConnector.addOntologyImport(TEXT_ONTOLOGY_IRI);
 
@@ -74,7 +84,6 @@ public class OntologyTextProvider implements ITextConnector {
         dependencySourceProperty = ontologyConnector.getObjectProperty("has source").orElseThrow();
         dependencyTargetProperty = ontologyConnector.getObjectProperty("has target").orElseThrow();
         dependencyTypeProperty = ontologyConnector.getAnnotationProperty("dependencyType").orElseThrow();
-
     }
 
     public void addText(IText text) {
@@ -149,7 +158,7 @@ public class OntologyTextProvider implements ITextConnector {
 
     @Override
     public IText getAnnotatedText() {
-        if (USE_CACHED) {
+        if (useCache) {
             return CachedOntologyText.get(ontologyConnector);
         } else {
             return OntologyText.get(ontologyConnector);

--- a/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/OntologyTextProvider.java
+++ b/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/OntologyTextProvider.java
@@ -3,11 +3,9 @@ package edu.kit.kastel.mcse.ardoco.core.text.providers.ontology;
 import java.util.ArrayList;
 import java.util.HashMap;
 
-import org.apache.jena.ontology.AnnotationProperty;
-import org.apache.jena.ontology.DatatypeProperty;
 import org.apache.jena.ontology.Individual;
-import org.apache.jena.ontology.ObjectProperty;
 import org.apache.jena.ontology.OntClass;
+import org.apache.jena.ontology.OntProperty;
 import org.apache.jena.vocabulary.XSD;
 
 import edu.kit.kastel.mcse.ardoco.core.datastructures.definitions.DependencyTag;
@@ -16,7 +14,7 @@ import edu.kit.kastel.mcse.ardoco.core.datastructures.definitions.IWord;
 import edu.kit.kastel.mcse.ardoco.core.ontology.OntologyConnector;
 import edu.kit.kastel.mcse.ardoco.core.text.providers.ITextConnector;
 
-public class OntologyTextProvider implements ITextConnector {
+public final class OntologyTextProvider implements ITextConnector {
     private static final String TEXT_ONTOLOGY_IRI = "https://informalin.github.io/knowledgebases/informalin_base_text.owl";
 
     private static boolean useCache = true;
@@ -27,16 +25,16 @@ public class OntologyTextProvider implements ITextConnector {
     private OntClass wordClass;
     private OntClass dependencyClass;
 
-    private DatatypeProperty uuidProperty;
-    private DatatypeProperty textProperty;
-    private DatatypeProperty posProperty;
-    private DatatypeProperty lemmaProperty;
-    private DatatypeProperty positionProperty;
-    private DatatypeProperty sentenceProperty;
-    private ObjectProperty wordsProperty;
-    private ObjectProperty dependencySourceProperty;
-    private ObjectProperty dependencyTargetProperty;
-    private AnnotationProperty dependencyTypeProperty;
+    private OntProperty uuidProperty;
+    private OntProperty textProperty;
+    private OntProperty posProperty;
+    private OntProperty lemmaProperty;
+    private OntProperty positionProperty;
+    private OntProperty sentenceProperty;
+    private OntProperty wordsProperty;
+    private OntProperty dependencySourceProperty;
+    private OntProperty dependencyTargetProperty;
+    private OntProperty dependencyTypeProperty;
 
     private OntologyTextProvider(OntologyConnector ontologyConnector) {
         this.ontologyConnector = ontologyConnector;
@@ -71,19 +69,19 @@ public class OntologyTextProvider implements ITextConnector {
     private void init() {
         ontologyConnector.addOntologyImport(TEXT_ONTOLOGY_IRI);
 
-        textClass = ontologyConnector.getClass("TextDocument").orElseThrow();
-        wordClass = ontologyConnector.getClass("Word").orElseThrow();
-        dependencyClass = ontologyConnector.getClass("WordDependency").orElseThrow();
-        uuidProperty = ontologyConnector.getDataProperty("uuid").orElseThrow();
-        textProperty = ontologyConnector.getDataProperty("has text").orElseThrow();
-        posProperty = ontologyConnector.getDataProperty("has POS").orElseThrow();
-        lemmaProperty = ontologyConnector.getDataProperty("has lemma").orElseThrow();
-        positionProperty = ontologyConnector.getDataProperty("has position").orElseThrow();
-        sentenceProperty = ontologyConnector.getDataProperty("contained in sentence").orElseThrow();
-        wordsProperty = ontologyConnector.getObjectProperty("has words").orElseThrow();
-        dependencySourceProperty = ontologyConnector.getObjectProperty("has source").orElseThrow();
-        dependencyTargetProperty = ontologyConnector.getObjectProperty("has target").orElseThrow();
-        dependencyTypeProperty = ontologyConnector.getAnnotationProperty("dependencyType").orElseThrow();
+        textClass = ontologyConnector.getClassByIri(CommonOntologyUris.TEXT_DOCUMENT_CLASS.getUri()).orElseThrow();
+        wordClass = ontologyConnector.getClassByIri(CommonOntologyUris.WORD_CLASS.getUri()).orElseThrow();
+        dependencyClass = ontologyConnector.getClassByIri(CommonOntologyUris.WORD_DEPENDENCY_CLASS.getUri()).orElseThrow();
+        uuidProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.UUID_PROPERTY.getUri()).orElseThrow();
+        textProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.TEXT_PROPERTY.getUri()).orElseThrow();
+        posProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.POS_PROPERTY.getUri()).orElseThrow();
+        lemmaProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.LEMMA_PROPERTY.getUri()).orElseThrow();
+        positionProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.POSITION_PROPERTY.getUri()).orElseThrow();
+        sentenceProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.SENTENCE_PROPERTY.getUri()).orElseThrow();
+        wordsProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.HAS_WORDS_PROPERTY.getUri()).orElseThrow();
+        dependencySourceProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.DEP_SOURCE_PROPERTY.getUri()).orElseThrow();
+        dependencyTargetProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.DEP_TARGET_PROPERTY.getUri()).orElseThrow();
+        dependencyTypeProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.DEP_TYPE_PROPERTY.getUri()).orElseThrow();
     }
 
     public void addText(IText text) {

--- a/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/OntologyWord.java
+++ b/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/OntologyWord.java
@@ -8,8 +8,6 @@ import java.util.Optional;
 import org.apache.jena.ontology.Individual;
 import org.apache.jena.ontology.OntProperty;
 import org.apache.jena.rdf.model.Resource;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
@@ -18,24 +16,9 @@ import edu.kit.kastel.mcse.ardoco.core.datastructures.definitions.DependencyTag;
 import edu.kit.kastel.mcse.ardoco.core.datastructures.definitions.IWord;
 import edu.kit.kastel.mcse.ardoco.core.datastructures.definitions.POSTag;
 import edu.kit.kastel.mcse.ardoco.core.ontology.OntologyConnector;
-import edu.kit.kastel.mcse.ardoco.core.ontology.OntologyInterface;
 
-public class OntologyWord implements IWord {
-    private static Logger logger = LogManager.getLogger(OntologyWord.class);
-
-    private static OntologyConnector ontologyConnector = null;
-
-    private static String textPropertyUri = "https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLDataProperty_2abdbab4_07a1_44e4_86b4_1dd2db60d093";
-    private static String posPropertyUri = "https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLDataProperty_4a42b4d3_f585_4d3a_ac8d_12efcd2f41ed";
-    private static String lemmaPropertyUri = "https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLDataProperty_8641228e_89c1_4094_8770_d6db4cff934d";
-    private static String positionPropertyUri = "https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLDataProperty_24a1fab1_8d82_4a64_a569_26181935ae92";
-    private static String sentencePropertyUri = "https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLDataProperty_cca1bf08_930a_4c38_b1b4_4b127db235a3";
-    private static String hasItemPropertyUri = "https://informalin.github.io/knowledgebases/external/olo/orderedlistontology.owl#item";
-    private static String hasNextPropertyUri = "https://informalin.github.io/knowledgebases/external/olo/orderedlistontology.owl#next";
-    private static String hasPreviousPropertyUri = "https://informalin.github.io/knowledgebases/external/olo/orderedlistontology.owl#previous";
-    private static String depSourcePropertyUri = "https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLObjectProperty_338dfb91_e78b_4145_bf8c_a952e927b6e9";
-    private static String depTargetPropertyUri = "https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLObjectProperty_82e64c17_5998_4d50_941f_a2b859c1a95b";
-    private static String depTypePropertyUri = "https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLAnnotationProperty_79e191d9_7e85_461e_ae42_62df5078719b";
+public final class OntologyWord implements IWord {
+    private OntologyConnector ontologyConnector = null;
 
     private OntProperty textProperty = null;
     private OntProperty posProperty = null;
@@ -51,39 +34,33 @@ public class OntologyWord implements IWord {
 
     private Individual wordIndividual;
 
-    private OntologyWord(Individual wordIndividual) {
+    private OntologyWord(OntologyConnector ontologyConnector, Individual wordIndividual) {
         this.wordIndividual = wordIndividual;
+        this.ontologyConnector = ontologyConnector;
     }
 
-    protected static OntologyWord get(OntologyConnector ontologyConnector, Individual wordIndividual) {
+    static OntologyWord get(OntologyConnector ontologyConnector, Individual wordIndividual) {
         if (ontologyConnector == null || wordIndividual == null) {
             return null;
         }
-        if (OntologyWord.ontologyConnector == null) {
-            OntologyWord.ontologyConnector = ontologyConnector;
-        }
-        if (!OntologyWord.ontologyConnector.equals(ontologyConnector)) {
-            logger.warn("There is a change in the OntologyConnector. This might cause illegal states!");
-            OntologyWord.ontologyConnector = ontologyConnector;
-        }
 
-        var ow = new OntologyWord(wordIndividual);
-        ow.init(ontologyConnector);
+        var ow = new OntologyWord(ontologyConnector, wordIndividual);
+        ow.init();
         return ow;
     }
 
-    private void init(OntologyInterface ontologyConnector) {
-        textProperty = ontologyConnector.getPropertyByIri(textPropertyUri).orElseThrow();
-        posProperty = ontologyConnector.getPropertyByIri(posPropertyUri).orElseThrow();
-        lemmaProperty = ontologyConnector.getPropertyByIri(lemmaPropertyUri).orElseThrow();
-        positionProperty = ontologyConnector.getPropertyByIri(positionPropertyUri).orElseThrow();
-        sentenceProperty = ontologyConnector.getPropertyByIri(sentencePropertyUri).orElseThrow();
-        hasItem = ontologyConnector.getPropertyByIri(hasItemPropertyUri).orElseThrow();
-        hasNext = ontologyConnector.getPropertyByIri(hasNextPropertyUri).orElseThrow();
-        hasPrevious = ontologyConnector.getPropertyByIri(hasPreviousPropertyUri).orElseThrow();
-        dependencySourceProperty = ontologyConnector.getPropertyByIri(depSourcePropertyUri).orElseThrow();
-        dependencyTargetProperty = ontologyConnector.getPropertyByIri(depTargetPropertyUri).orElseThrow();
-        dependencyTypeProperty = ontologyConnector.getPropertyByIri(depTypePropertyUri).orElseThrow();
+    private void init() {
+        textProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.TEXT_PROPERTY.getUri()).orElseThrow();
+        posProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.POS_PROPERTY.getUri()).orElseThrow();
+        lemmaProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.LEMMA_PROPERTY.getUri()).orElseThrow();
+        positionProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.POSITION_PROPERTY.getUri()).orElseThrow();
+        sentenceProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.SENTENCE_PROPERTY.getUri()).orElseThrow();
+        hasItem = ontologyConnector.getPropertyByIri(CommonOntologyUris.HAS_ITEM_PROPERTY.getUri()).orElseThrow();
+        hasNext = ontologyConnector.getPropertyByIri(CommonOntologyUris.HAS_NEXT_PROPERTY.getUri()).orElseThrow();
+        hasPrevious = ontologyConnector.getPropertyByIri(CommonOntologyUris.HAS_PREVIOUS_PROPERTY.getUri()).orElseThrow();
+        dependencySourceProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.DEP_SOURCE_PROPERTY.getUri()).orElseThrow();
+        dependencyTargetProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.DEP_TARGET_PROPERTY.getUri()).orElseThrow();
+        dependencyTypeProperty = ontologyConnector.getPropertyByIri(CommonOntologyUris.DEP_TYPE_PROPERTY.getUri()).orElseThrow();
     }
 
     @Override
@@ -142,7 +119,7 @@ public class OntologyWord implements IWord {
         return null;
     }
 
-    private static Optional<Individual> extractItemOutOfSlot(Individual slot) {
+    private Optional<Individual> extractItemOutOfSlot(Individual slot) {
         if (slot == null) {
             return Optional.empty();
         }
@@ -222,7 +199,7 @@ public class OntologyWord implements IWord {
         return createWordsFromIndividuals(targets);
     }
 
-    private static ImmutableList<IWord> createWordsFromIndividuals(List<Individual> individuals) {
+    private ImmutableList<IWord> createWordsFromIndividuals(List<Individual> individuals) {
         MutableList<IWord> words = Lists.mutable.empty();
         for (var individual : individuals) {
             words.add(OntologyWord.get(ontologyConnector, individual));
@@ -230,7 +207,7 @@ public class OntologyWord implements IWord {
         return words.toImmutable();
     }
 
-    private static List<Individual> extractIndividualsInRelation(List<Individual> filteredDependencies, OntProperty property) {
+    private List<Individual> extractIndividualsInRelation(List<Individual> filteredDependencies, OntProperty property) {
         var targets = new ArrayList<Individual>();
         for (var dependency : filteredDependencies) {
             var targetNode = ontologyConnector.getPropertyValue(dependency, property);
@@ -242,7 +219,7 @@ public class OntologyWord implements IWord {
         return targets;
     }
 
-    private static List<Individual> filterDependencyResourcesByType(DependencyTag dependencyTag, List<Resource> dependencies) {
+    private List<Individual> filterDependencyResourcesByType(DependencyTag dependencyTag, List<Resource> dependencies) {
         var filteredDependencies = new ArrayList<Individual>();
         for (var dependency : dependencies) {
             var depIndividual = ontologyConnector.transformIntoIndividual(dependency);

--- a/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/OntologyWord.java
+++ b/text-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/ontology/OntologyWord.java
@@ -37,17 +37,17 @@ public class OntologyWord implements IWord {
     private static String depTargetPropertyUri = "https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLObjectProperty_82e64c17_5998_4d50_941f_a2b859c1a95b";
     private static String depTypePropertyUri = "https://informalin.github.io/knowledgebases/informalin_base_text.owl#OWLAnnotationProperty_79e191d9_7e85_461e_ae42_62df5078719b";
 
-    private static OntProperty textProperty = null;
-    private static OntProperty posProperty = null;
-    private static OntProperty lemmaProperty = null;
-    private static OntProperty positionProperty = null;
-    private static OntProperty sentenceProperty = null;
-    private static OntProperty hasItem = null;
-    private static OntProperty hasNext = null;
-    private static OntProperty hasPrevious = null;
-    private static OntProperty dependencySourceProperty = null;
-    private static OntProperty dependencyTargetProperty = null;
-    private static OntProperty dependencyTypeProperty = null;
+    private OntProperty textProperty = null;
+    private OntProperty posProperty = null;
+    private OntProperty lemmaProperty = null;
+    private OntProperty positionProperty = null;
+    private OntProperty sentenceProperty = null;
+    private OntProperty hasItem = null;
+    private OntProperty hasNext = null;
+    private OntProperty hasPrevious = null;
+    private OntProperty dependencySourceProperty = null;
+    private OntProperty dependencyTargetProperty = null;
+    private OntProperty dependencyTypeProperty = null;
 
     private Individual wordIndividual;
 
@@ -65,16 +65,14 @@ public class OntologyWord implements IWord {
         if (!OntologyWord.ontologyConnector.equals(ontologyConnector)) {
             logger.warn("There is a change in the OntologyConnector. This might cause illegal states!");
             OntologyWord.ontologyConnector = ontologyConnector;
-            textProperty = null; // to renew the init below
         }
-        if (textProperty == null) {
-            // if textProperty is null, we assume we need to initialize the static variables
-            init(ontologyConnector);
-        }
-        return new OntologyWord(wordIndividual);
+
+        var ow = new OntologyWord(wordIndividual);
+        ow.init(ontologyConnector);
+        return ow;
     }
 
-    private static void init(OntologyInterface ontologyConnector) {
+    private void init(OntologyInterface ontologyConnector) {
         textProperty = ontologyConnector.getPropertyByIri(textPropertyUri).orElseThrow();
         posProperty = ontologyConnector.getPropertyByIri(posPropertyUri).orElseThrow();
         lemmaProperty = ontologyConnector.getPropertyByIri(lemmaPropertyUri).orElseThrow();

--- a/util/src/main/java/edu/kit/kastel/mcse/ardoco/core/datastructures/common/SimilarityUtils.java
+++ b/util/src/main/java/edu/kit/kastel/mcse/ardoco/core/datastructures/common/SimilarityUtils.java
@@ -37,13 +37,18 @@ public final class SimilarityUtils {
      * @return true, if the test string is similar to the original; false if not.
      */
     public static boolean areWordsSimilar(String original, String word2test, Double threshold) {
-        if (original.toLowerCase().split(" ").length != word2test.toLowerCase().split(" ").length) {
+        if (original == null || word2test == null) {
+            return false;
+        }
+        String originalLowerCase = original.toLowerCase();
+        String word2TestLowerCase = word2test.toLowerCase();
+        if (originalLowerCase.split(" ").length != word2TestLowerCase.split(" ").length) {
             return false;
         }
         int areWordsSimilarMinLength = CommonTextToolsConfig.ARE_WORDS_SIMILAR_MIN_LENGTH;
         int areWordsSimilarMaxLdist = CommonTextToolsConfig.ARE_WORDS_SIMILAR_MAX_L_DIST;
-        int ldist = ldistance.apply(original.toLowerCase(), word2test.toLowerCase());
-        int lcscount = getLongestCommonSubstring(original.toLowerCase(), word2test.toLowerCase());
+        int ldist = ldistance.apply(originalLowerCase, word2TestLowerCase);
+        int lcscount = getLongestCommonSubstring(originalLowerCase, word2TestLowerCase);
         if (original.length() <= areWordsSimilarMinLength) {
             if (ldist <= areWordsSimilarMaxLdist && lcscount == original.length()) {
                 return true;


### PR DESCRIPTION
Fixes #27 with commit 25ce88d2844d2481b9a06fce317129a3377691ca
The problem was that for the getter-Methods etc., the underlying OntologyWord was asked. If the return type was an IWord, the results was not wrapped into a CachedOntologyWord. Therefore, the equals()-Method usually returned false as the types were not equal.