### PR TITLE
Add baseline approach for Inconsistency

### DIFF
--- a/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/agents/MissingModelElementInconsistencyAgent.java
+++ b/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/agents/MissingModelElementInconsistencyAgent.java
@@ -35,7 +35,6 @@ public class MissingModelElementInconsistencyAgent extends InconsistencyAgent {
         for (var model : data.getModelIds()) {
             var inconsistencyState = data.getInconsistencyState(model);
             var connectionState = data.getConnectionState(model);
-            var recommendationState = data.getRecommendationState(data.getModelState(model).getMetamodel());
 
             var candidates = Sets.mutable.<MissingElementInconsistencyCandidate> empty();
 

--- a/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/MissingModelInstanceInconsistency.java
+++ b/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/MissingModelInstanceInconsistency.java
@@ -18,15 +18,15 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.textextraction.MappingKind;
 public record MissingModelInstanceInconsistency(IRecommendedInstance textualInstance) implements IInconsistency {
     private static final String INCONSISTENCY_TYPE_NAME = "MissingModelInstance";
 
-    private static final String REASON_FORMAT_STRING = "Text indicates (confidence: %.2f) that \"%s\" should be contained in the model(s) but could not be found. Sentences: %s";
-
     @Override
     public String getReason() {
         var name = textualInstance.getName();
         var occurrences = getOccurrencesString();
 
         var confidence = textualInstance.getProbability();
-        return String.format(Locale.US, REASON_FORMAT_STRING, confidence, name, occurrences);
+        return String.format(Locale.US,
+                "Text indicates (confidence: %.2f) that \"%s\" should be contained in the model(s) but could not be found. Sentences: %s", confidence, name,
+                occurrences);
     }
 
     private String getOccurrencesString() {

--- a/inconsistency-detection/src/test/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/MissingModelInstanceInconsistencyTest.java
+++ b/inconsistency-detection/src/test/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/MissingModelInstanceInconsistencyTest.java
@@ -14,6 +14,8 @@ import edu.kit.kastel.mcse.ardoco.core.recommendationgenerator.RecommendedInstan
 import edu.kit.kastel.mcse.ardoco.core.textextraction.NounMapping;
 
 /**
+ * This class tests the record MissingModelInconsistency.
+ * 
  * @author Jan Keim
  */
 public class MissingModelInstanceInconsistencyTest extends AbstractInconsistencyTypeTest implements IClaimant {
@@ -23,8 +25,8 @@ public class MissingModelInstanceInconsistencyTest extends AbstractInconsistency
     @BeforeEach
     void beforeEach() {
         ImmutableList<IWord> words = Lists.immutable.of(new DummyWord());
-        ImmutableList<String> occurences = Lists.immutable.of("occurence");
-        var nounMapping = new NounMapping(words, MappingKind.NAME, this, 1.0, words.toList(), occurences);
+        ImmutableList<String> occurrences = Lists.immutable.of("occurrence");
+        var nounMapping = new NounMapping(words, MappingKind.NAME, this, 1.0, words.toList(), occurrences);
         var recommendedInstance = new RecommendedInstance("name", "type", this, 1.0, Lists.immutable.of(nounMapping), Lists.immutable.empty());
         missingModelInstanceInconsistency = new MissingModelInstanceInconsistency(recommendedInstance);
     }

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/inconsistencies/baseline/DeleteOneModelElementBaselineEval.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/inconsistencies/baseline/DeleteOneModelElementBaselineEval.java
@@ -1,0 +1,19 @@
+/* Licensed under MIT 2022. */
+package edu.kit.kastel.mcse.ardoco.core.tests.inconsistencies.baseline;
+
+import java.util.Map;
+
+import edu.kit.kastel.mcse.ardoco.core.api.data.DataStructure;
+import edu.kit.kastel.mcse.ardoco.core.api.stage.IExecutionStage;
+import edu.kit.kastel.mcse.ardoco.core.tests.inconsistencies.eval.model.DeleteOneModelElementEval;
+
+public class DeleteOneModelElementBaselineEval extends DeleteOneModelElementEval {
+
+    @Override
+    protected DataStructure runInconsistencyChecker(DataStructure data, Map<String, String> configs) {
+        IExecutionStage inconsistencyChecker = new InconsistencyBaseline();
+        inconsistencyChecker.execute(data, configs);
+        return data;
+    }
+
+}

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/inconsistencies/baseline/InconsistencyBaseline.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/inconsistencies/baseline/InconsistencyBaseline.java
@@ -1,0 +1,40 @@
+/* Licensed under MIT 2022. */
+package edu.kit.kastel.mcse.ardoco.core.tests.inconsistencies.baseline;
+
+import java.util.Map;
+
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.set.MutableSet;
+
+import edu.kit.kastel.mcse.ardoco.core.api.data.DataStructure;
+import edu.kit.kastel.mcse.ardoco.core.api.data.connectiongenerator.TraceLink;
+import edu.kit.kastel.mcse.ardoco.core.api.data.inconsistency.IInconsistencyState;
+import edu.kit.kastel.mcse.ardoco.core.api.data.text.ISentence;
+import edu.kit.kastel.mcse.ardoco.core.api.stage.AbstractExecutionStage;
+import edu.kit.kastel.mcse.ardoco.core.inconsistency.InconsistencyState;
+
+public class InconsistencyBaseline extends AbstractExecutionStage {
+
+    public InconsistencyBaseline() {
+        super();
+    }
+
+    @Override
+    public void execute(DataStructure data, Map<String, String> additionalSettings) {
+        data.getModelIds().forEach(mid -> data.setInconsistencyState(mid, new InconsistencyState(additionalSettings)));
+        this.applyConfiguration(additionalSettings);
+
+        var sentences = Sets.mutable.fromStream(data.getText().getSentences().stream().map(ISentence::getSentenceNumber));
+        for (var model : data.getModelIds()) {
+            var traceLinks = data.getConnectionState(model).getTraceLinks();
+            var sentencesWithTraceLinks = traceLinks.collect(TraceLink::getSentenceNumber).toSet();
+            MutableSet<Integer> sentencesWithoutTraceLinks = sentences.withoutAll(sentencesWithTraceLinks);
+
+            IInconsistencyState inconsistencyState = data.getInconsistencyState(model);
+            for (var sentence : sentencesWithoutTraceLinks) {
+                inconsistencyState.addInconsistency(new SimpleMissingModelInstanceInconsistency(sentence));
+            }
+        }
+
+    }
+}

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/inconsistencies/baseline/SimpleMissingModelInstanceInconsistency.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/inconsistencies/baseline/SimpleMissingModelInstanceInconsistency.java
@@ -1,0 +1,59 @@
+/* Licensed under MIT 2022. */
+package edu.kit.kastel.mcse.ardoco.core.tests.inconsistencies.baseline;
+
+import org.eclipse.collections.api.collection.ImmutableCollection;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.set.MutableSet;
+
+import edu.kit.kastel.mcse.ardoco.core.api.data.inconsistency.IInconsistency;
+
+public record SimpleMissingModelInstanceInconsistency(int sentenceNo) implements IInconsistency {
+
+    @Override
+    public String getReason() {
+        return "MissingModelInstanceInconsistency in sentence " + sentenceNo;
+    }
+
+    @Override
+    public String getType() {
+        return "SimpleMissingModelInstance";
+    }
+
+    @Override
+    public ImmutableCollection<String[]> toFileOutput() {
+        MutableSet<String[]> entries = Sets.mutable.empty();
+
+        var sentenceNoString = "" + sentenceNo;
+        String[] entry = { getType(), sentenceNoString, "_", Integer.toString(sentenceNo), Double.toString(0.1337) };
+        entries.add(entry);
+
+        return entries.toImmutable();
+    }
+
+    @Override
+    public IInconsistency createCopy() {
+        return new SimpleMissingModelInstanceInconsistency(sentenceNo);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof SimpleMissingModelInstanceInconsistency))
+            return false;
+
+        SimpleMissingModelInstanceInconsistency that = (SimpleMissingModelInstanceInconsistency) o;
+
+        return sentenceNo == that.sentenceNo;
+    }
+
+    @Override
+    public int hashCode() {
+        return sentenceNo;
+    }
+
+    @Override
+    public String toString() {
+        return "SimpelMissingModelInstanceInconsistency{" + "sentenceNo=" + sentenceNo + '}';
+    }
+}

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/inconsistencies/eval/AbstractEvalStrategy.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/inconsistencies/eval/AbstractEvalStrategy.java
@@ -20,7 +20,7 @@ public abstract class AbstractEvalStrategy implements IEvaluationStrategy {
         super();
     }
 
-    protected static DataStructure runRecommendationConnectionInconsistency(DataStructure data) {
+    protected DataStructure runRecommendationConnectionInconsistency(DataStructure data) {
         Map<String, String> config = new HashMap<>();
         // Model Extractor has been executed & textExtractor does not depend on model changes
         runRecommendationGenerator(data, config);
@@ -29,30 +29,30 @@ public abstract class AbstractEvalStrategy implements IEvaluationStrategy {
         return data;
     }
 
-    protected static IModelState runModelExtractor(IModelConnector modelConnector, Map<String, String> configs) {
+    protected IModelState runModelExtractor(IModelConnector modelConnector, Map<String, String> configs) {
         ModelProvider modelExtractor = new ModelProvider(modelConnector);
         return modelExtractor.execute(configs);
     }
 
-    protected static DataStructure runTextExtractor(DataStructure data, Map<String, String> configs) {
+    protected DataStructure runTextExtractor(DataStructure data, Map<String, String> configs) {
         IExecutionStage textModule = new TextExtraction();
         textModule.execute(data, configs);
         return data;
     }
 
-    private static DataStructure runRecommendationGenerator(DataStructure data, Map<String, String> configs) {
+    protected DataStructure runRecommendationGenerator(DataStructure data, Map<String, String> configs) {
         IExecutionStage recommendationModule = new RecommendationGenerator();
         recommendationModule.execute(data, configs);
         return data;
     }
 
-    private static DataStructure runConnectionGenerator(DataStructure data, Map<String, String> configs) {
+    protected DataStructure runConnectionGenerator(DataStructure data, Map<String, String> configs) {
         IExecutionStage connectionGenerator = new ConnectionGenerator();
         connectionGenerator.execute(data, configs);
         return data;
     }
 
-    private static DataStructure runInconsistencyChecker(DataStructure data, Map<String, String> configs) {
+    protected DataStructure runInconsistencyChecker(DataStructure data, Map<String, String> configs) {
         IExecutionStage inconsistencyChecker = new InconsistencyChecker();
         inconsistencyChecker.execute(data, configs);
         return data;

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/inconsistencies/eval/model/DeleteOneModelElementEval.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/inconsistencies/eval/model/DeleteOneModelElementEval.java
@@ -6,16 +6,20 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.block.factory.Predicates;
 
 import edu.kit.kastel.mcse.ardoco.core.api.data.DataStructure;
+import edu.kit.kastel.mcse.ardoco.core.api.data.inconsistency.IInconsistency;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.IModelInstance;
 import edu.kit.kastel.mcse.ardoco.core.api.data.text.IText;
 import edu.kit.kastel.mcse.ardoco.core.inconsistency.types.MissingModelInstanceInconsistency;
 import edu.kit.kastel.mcse.ardoco.core.model.IModelConnector;
 import edu.kit.kastel.mcse.ardoco.core.tests.Project;
+import edu.kit.kastel.mcse.ardoco.core.tests.inconsistencies.baseline.SimpleMissingModelInstanceInconsistency;
 import edu.kit.kastel.mcse.ardoco.core.tests.inconsistencies.eval.AbstractEvalStrategy;
 import edu.kit.kastel.mcse.ardoco.core.tests.inconsistencies.eval.EvaluationResult;
 import edu.kit.kastel.mcse.ardoco.core.tests.inconsistencies.eval.GoldStandard;
@@ -48,7 +52,7 @@ public class DeleteOneModelElementEval extends AbstractEvalStrategy {
         return evaluator.getWeightedAveragePRF1();
     }
 
-    private static Map<ModifiedElement<IModelConnector, IModelInstance>, DataStructure> process(IModelConnector pcmModel, IText annotatedText,
+    private Map<ModifiedElement<IModelConnector, IModelInstance>, DataStructure> process(IModelConnector pcmModel, IText annotatedText,
             IModificationStrategy strategy) {
         var configurations = new HashMap<String, String>();
         Map<ModifiedElement<IModelConnector, IModelInstance>, DataStructure> results = new HashMap<>();
@@ -82,8 +86,7 @@ public class DeleteOneModelElementEval extends AbstractEvalStrategy {
             var inconsistencySentences = r.getValue()
                     .getInconsistencyState(modelId)
                     .getInconsistencies()
-                    .select(MissingModelInstanceInconsistency.class::isInstance)
-                    .collect(MissingModelInstanceInconsistency.class::cast)
+                    .select(selectMissingModelInconsistencies())
                     .flatCollect(this::foundSentences)
                     .toSet();
             var outputString = "ORIGINAL: Number of False Positives (assuming consistency for original): " + inconsistencySentences.size();
@@ -97,13 +100,11 @@ public class DeleteOneModelElementEval extends AbstractEvalStrategy {
         var sentencesAnnotatedWithElement = gs.getSentencesWithElement(deletedElement).toSortedSet().toImmutable();
 
         var newInconsistencies = r.getValue().getInconsistencyState(modelId).getInconsistencies();
-        var newMissingModelInstanceInconsistencies = newInconsistencies //
-                .select(MissingModelInstanceInconsistency.class::isInstance) //
-                .collect(MissingModelInstanceInconsistency.class::cast);
+        var newMissingModelInstanceInconsistencies = newInconsistencies.select(selectMissingModelInconsistencies()).flatCollect(this::foundSentences).toSet();
 
         os.println("Stats: New: " + newInconsistencies.size() + ", New MissingModelInstanceInconsistencies: " + newMissingModelInstanceInconsistencies.size());
 
-        var foundSentencesWithDuplicatesOverInconsistencies = newMissingModelInstanceInconsistencies.flatCollect(this::foundSentences).toSortedSet();
+        var foundSentencesWithDuplicatesOverInconsistencies = newMissingModelInstanceInconsistencies.toSortedSet();
 
         os.println("Is   : " + foundSentencesWithDuplicatesOverInconsistencies);
         os.println("Shall: " + sentencesAnnotatedWithElement);
@@ -118,12 +119,21 @@ public class DeleteOneModelElementEval extends AbstractEvalStrategy {
         os.println("-----------------------------------");
     }
 
-    private ImmutableList<Integer> foundSentences(MissingModelInstanceInconsistency newImportantInconsistency) {
-        MutableList<Integer> sentences = Lists.mutable.empty();
-        for (var nouns : newImportantInconsistency.getTextualInstance().getNameMappings()) {
-            sentences.addAll(nouns.getMappingSentenceNo().castToCollection());
+    private Predicate<IInconsistency> selectMissingModelInconsistencies() {
+        return Predicates.or(SimpleMissingModelInstanceInconsistency.class::isInstance, MissingModelInstanceInconsistency.class::isInstance);
+    }
+
+    private ImmutableList<Integer> foundSentences(IInconsistency inconsistency) {
+        if (inconsistency instanceof SimpleMissingModelInstanceInconsistency simpleMissingModelInstanceInconsistency) {
+            return Lists.immutable.of(simpleMissingModelInstanceInconsistency.sentenceNo());
+        } else if (inconsistency instanceof MissingModelInstanceInconsistency missingModelInstanceInconsistency) {
+            MutableList<Integer> sentences = Lists.mutable.empty();
+            for (var nouns : missingModelInstanceInconsistency.getTextualInstance().getNameMappings()) {
+                sentences.addAll(nouns.getMappingSentenceNo().castToCollection());
+            }
+            return sentences.distinct().toImmutable();
         }
-        return sentences.distinct().toImmutable();
+        return Lists.immutable.empty();
     }
 
 }


### PR DESCRIPTION
Added InconsistencyBaseline that calls out a SimpleMissingModelInstanceInconsistency for each sentence where there is no trace link reported by TLR step.