### PR TITLE
Remove @author tags

### DIFF
--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/Confidence.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/Confidence.java
@@ -16,9 +16,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.agent.Claimant;
 /**
  *
  *
- * @author Sophie Schulz
- * @author Dominik Fuchß
- * @author Jan Keim
  *
  */
 public final class Confidence implements Comparable<Confidence>, ICopyable<Confidence> {

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/connectiongenerator/TraceLink.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/connectiongenerator/TraceLink.java
@@ -10,7 +10,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.text.Word;
  * Represents a trace link. This is a convenience data class that takes the necessary info from {@link InstanceLink} and
  * the specific {@link ModelInstance} and {@link Word} that are used in this trace link.
  *
- * @author Jan Keim
  */
 public class TraceLink {
     private final InstanceLink instanceLink;

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/inconsistency/InconsistencyState.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/inconsistency/InconsistencyState.java
@@ -13,7 +13,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.recommendationgenerator.Recommen
 /**
  * Inconsistency state holding data and information about inconsistency.
  * 
- * @author Jan Keim
  */
 public interface InconsistencyState extends ICopyable<InconsistencyState>, IConfigurable {
 

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/text/POSTag.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/text/POSTag.java
@@ -7,9 +7,6 @@ import org.slf4j.LoggerFactory;
 /**
  * This class represents all valid part-of-speech (pos) tags
  *
- * @author Sebastian Weigelt
- * @author Markus Kocybik
- * @author Jan Keim
  */
 public enum POSTag {
     //@formatter:off

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/text/Sentence.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/text/Sentence.java
@@ -6,7 +6,6 @@ import org.eclipse.collections.api.list.ImmutableList;
 /**
  * Represents a sentence within the document.
  *
- * @author Jan Keim
  *
  */
 public interface Sentence {

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/textextraction/MappingKind.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/textextraction/MappingKind.java
@@ -4,7 +4,6 @@ package edu.kit.kastel.mcse.ardoco.core.api.data.textextraction;
 /**
  * The mapping type of a mapping states whether the mapping is a name or a type.
  *
- * @author Sophie
  *
  */
 public enum MappingKind {

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/CommonUtilities.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/CommonUtilities.java
@@ -24,7 +24,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.textextraction.TextState;
 /**
  * General helper class for outsourced, common methods.
  *
- * @author Sophie
  */
 public final class CommonUtilities {
 

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/SimilarityUtils.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/SimilarityUtils.java
@@ -15,7 +15,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.textextraction.NounMapping;
 /**
  * This class is a utility class.
  *
- * @author Sophie, Jan
  */
 public final class SimilarityUtils {
 

--- a/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/ConnectionGenerator.java
+++ b/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/ConnectionGenerator.java
@@ -22,7 +22,6 @@ import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.agents.ReferenceAgent
  * matchings between text and model. The order is important: All connections should run after the recommendations have
  * been made.
  *
- * @author Sophie
  */
 public class ConnectionGenerator extends AbstractExecutionStage {
 

--- a/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/ConnectionStateImpl.java
+++ b/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/ConnectionStateImpl.java
@@ -19,7 +19,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.recommendationgenerator.Recommen
  * The connection state encapsulates all connections between the model extraction state and the recommendation state.
  * These connections are stored in instance and relation links.
  *
- * @author Sophie
  */
 public class ConnectionStateImpl extends AbstractState implements ConnectionState {
 

--- a/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/InstanceLinkImpl.java
+++ b/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/InstanceLinkImpl.java
@@ -20,7 +20,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.textextraction.NounMapping;
 /**
  * Represents a trace link between an instance of the extracted model and a recommended instance.
  *
- * @author Sophie
  */
 public class InstanceLinkImpl implements InstanceLink {
 

--- a/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/InstanceConnectionAgent.java
+++ b/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/InstanceConnectionAgent.java
@@ -13,7 +13,6 @@ import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.extractors.InstantCon
 /**
  * This connector finds names of model instance in recommended instances.
  *
- * @author Sophie
  */
 public class InstanceConnectionAgent extends PipelineAgent {
     private final List<Informant> extractors;

--- a/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/ReferenceAgent.java
+++ b/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/ReferenceAgent.java
@@ -14,7 +14,6 @@ import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.extractors.ReferenceE
  * The reference solver finds instances mentioned in the text extraction state as names. If it founds some similar names
  * it creates recommendations.
  *
- * @author Sophie
  */
 public class ReferenceAgent extends PipelineAgent {
 

--- a/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/extractors/ExtractionDependentOccurrenceExtractor.java
+++ b/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/extractors/ExtractionDependentOccurrenceExtractor.java
@@ -18,8 +18,6 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.SimilarityUtils;
  * This analyzer searches for the occurrence of instance names and types of the extraction state and adds them as names
  * and types to the text extraction state.
  *
- * @author Sophie schulz
- * @author Jan Keim
  */
 public class ExtractionDependentOccurrenceExtractor extends Informant {
 

--- a/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/extractors/NameTypeConnectionExtractor.java
+++ b/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/extractors/NameTypeConnectionExtractor.java
@@ -26,7 +26,6 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.SimilarityUtils;
 /**
  * This analyzer searches for name type patterns. If these patterns occur recommendations are created.
  *
- * @author Sophie Schulz, Jan Keim
  */
 public class NameTypeConnectionExtractor extends Informant {
 

--- a/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/InconsistencyStateImpl.java
+++ b/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/InconsistencyStateImpl.java
@@ -13,7 +13,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.inconsistency.InconsistencyState
 import edu.kit.kastel.mcse.ardoco.core.api.data.recommendationgenerator.RecommendedInstance;
 
 /**
- * @author Jan Keim
  */
 public class InconsistencyStateImpl extends AbstractState implements InconsistencyState {
 

--- a/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/informants/OccasionFilter.java
+++ b/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/informants/OccasionFilter.java
@@ -16,7 +16,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.textextraction.NounMapping;
 /**
  * Filters {@link RecommendedInstance}s that occur only once in the text, thus are unlikely to be important entities.
  *
- * @author Jan Keim
  *
  */
 public class OccasionFilter extends Filter {

--- a/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/informants/RecommendedInstanceProbabilityFilter.java
+++ b/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/informants/RecommendedInstanceProbabilityFilter.java
@@ -20,7 +20,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.textextraction.NounMapping;
  * probability of being a {@link RecommendedInstance} is low or because the probability of having a mapping for a name
  * and/or type is low.
  *
- * @author Jan Keim
  *
  */
 public class RecommendedInstanceProbabilityFilter extends Filter {

--- a/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/MissingTextForModelElementInconsistency.java
+++ b/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/MissingTextForModelElementInconsistency.java
@@ -11,7 +11,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.inconsistency.Inconsistency;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelInstance;
 
 /**
- * @author Jan Keim
  */
 public class MissingTextForModelElementInconsistency implements Inconsistency {
     private static final String INCONSISTENCY_TYPE_NAME = "MissingTextForModelElement";

--- a/inconsistency-detection/src/test/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/AbstractInconsistencyTypeTest.java
+++ b/inconsistency-detection/src/test/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/AbstractInconsistencyTypeTest.java
@@ -16,7 +16,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.text.Sentence;
 import edu.kit.kastel.mcse.ardoco.core.api.data.text.Word;
 
 /**
- * @author Jan Keim
  *
  */
 public abstract class AbstractInconsistencyTypeTest {

--- a/inconsistency-detection/src/test/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/MissingModelInstanceInconsistencyTest.java
+++ b/inconsistency-detection/src/test/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/MissingModelInstanceInconsistencyTest.java
@@ -9,7 +9,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.inconsistency.Inconsistency;
 /**
  * This class tests the record MissingModelInconsistency.
  * 
- * @author Jan Keim
  */
 public class MissingModelInstanceInconsistencyTest extends AbstractInconsistencyTypeTest implements Claimant {
 

--- a/inconsistency-detection/src/test/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/MissingTextForModelElementInconsistencyTest.java
+++ b/inconsistency-detection/src/test/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/MissingTextForModelElementInconsistencyTest.java
@@ -8,7 +8,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelInstance;
 import edu.kit.kastel.mcse.ardoco.core.model.ModelInstanceImpl;
 
 /**
- * @author Jan Keim
  *
  */
 public class MissingTextForModelElementInconsistencyTest extends AbstractInconsistencyTypeTest {

--- a/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/model/ModelExtractionStateImpl.java
+++ b/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/model/ModelExtractionStateImpl.java
@@ -17,7 +17,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelInstance;
  * This state contains all from the model extracted information. This are the extracted instances and relations. For
  * easier handling, the occurring types and names are stored additionally.
  *
- * @author Sophie
  */
 public class ModelExtractionStateImpl extends AbstractState implements ModelExtractionState {
 

--- a/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/model/ModelInstanceImpl.java
+++ b/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/model/ModelInstanceImpl.java
@@ -15,7 +15,6 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.CommonUtilities;
  * at spaces and can be seen as multiple names. Therefore, the longestName (and type) is the original name (type) of the
  * instance.
  *
- * @author Sophie
  */
 public class ModelInstanceImpl implements ModelInstance {
 

--- a/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/model/ModelProvider.java
+++ b/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/model/ModelProvider.java
@@ -15,7 +15,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelStates;
  * The model extractor extracts the instances and relations via an connector. The extracted items are stored in a model
  * extraction state.
  *
- * @author Sophie
  */
 public final class ModelProvider extends AbstractPipelineStep {
     private static final String MODEL_STATES_DATA = "ModelStatesData";

--- a/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/RecommendationStateImpl.java
+++ b/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/RecommendationStateImpl.java
@@ -18,7 +18,6 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.SimilarityUtils;
  * The recommendation state encapsulates all recommended instances and relations. These recommendations should be
  * contained by the model by their probability.
  *
- * @author Sophie
  */
 public class RecommendationStateImpl extends AbstractState implements RecommendationState {
 

--- a/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/RecommendedInstanceImpl.java
+++ b/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/RecommendedInstanceImpl.java
@@ -24,7 +24,6 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.CommonUtilities;
  * This class represents recommended instances. These instances should be contained by the model. The likelihood is
  * measured by the probability. Every recommended instance has a unique name.
  *
- * @author Sophie
  */
 public class RecommendedInstanceImpl implements RecommendedInstance, Claimant {
 

--- a/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/extractors/NameTypeExtractor.java
+++ b/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/extractors/NameTypeExtractor.java
@@ -19,8 +19,6 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.DataRepositoryHelper;
 /**
  * This analyzer searches for name type patterns. If these patterns occur recommendations are created.
  *
- * @author Sophie Schulz
- * @author Jan Keim
  */
 public class NameTypeExtractor extends Informant {
 

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/ConfigurationTest.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/ConfigurationTest.java
@@ -1,23 +1,28 @@
 /* Licensed under MIT 2022. */
 package edu.kit.kastel.mcse.ardoco.core.tests;
 
-import edu.kit.kastel.informalin.data.DataRepository;
-import edu.kit.kastel.informalin.framework.configuration.AbstractConfigurable;
-import edu.kit.kastel.informalin.framework.configuration.Configurable;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.reflections.Reflections;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
-import java.util.*;
-import java.util.stream.Collectors;
+import edu.kit.kastel.informalin.data.DataRepository;
+import edu.kit.kastel.informalin.framework.configuration.AbstractConfigurable;
+import edu.kit.kastel.informalin.framework.configuration.Configurable;
 
 /**
  * This test class deals with the configurations.
  *
- * @author Dominik Fuchss
  * @see AbstractConfigurable
  */
 class ConfigurationTest {

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/Project.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/Project.java
@@ -11,7 +11,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelConnector;
 /**
  * This enum captures the different case studies that are used for evaluation in the integration tests.
  *
- * @author Jan Keim
  *
  */
 public enum Project {

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/InconsistencyDetectionEvaluationIT.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/InconsistencyDetectionEvaluationIT.java
@@ -44,7 +44,6 @@ import edu.kit.kastel.mcse.ardoco.core.tests.integration.inconsistencyhelper.Hol
  * a missing element and the trace links to this element (in the gold standard) are the spots of inconsistency then. We
  * run this multiple times so each element was held back once.
  *
- * @author Jan Keim
  */
 class InconsistencyDetectionEvaluationIT {
     private static final Logger logger = LoggerFactory.getLogger(InconsistencyDetectionEvaluationIT.class);

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceabilityLinkRecoveryEvaluationIT.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceabilityLinkRecoveryEvaluationIT.java
@@ -49,7 +49,6 @@ import edu.kit.kastel.mcse.ardoco.core.tests.integration.tlrhelper.files.TLSumma
  * Integration test that evaluates the traceability link recovery capabilities of ArDoCo. Runs on the projects that are
  * defined in the enum {@link Project}.
  * 
- * @author Jan Keim
  *
  */
 class TraceabilityLinkRecoveryEvaluationIT {

--- a/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/NounMappingImpl.java
+++ b/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/NounMappingImpl.java
@@ -27,8 +27,6 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.SimilarityUtils;
 /**
  * The Class NounMapping is a basic realization of {@link NounMapping}.
  *
- * @author Sophie Schulz
- * @author Jan Keim
  */
 public class NounMappingImpl implements NounMapping {
 

--- a/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/TextStateImpl.java
+++ b/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/TextStateImpl.java
@@ -20,8 +20,6 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.SimilarityUtils;
 /**
  * The Class TextState defines the basic implementation of a {@link TextState}.
  *
- * @author Sophie Schulz
- * @author Jan Keim
  */
 public class TextStateImpl extends AbstractState implements TextState {
 

--- a/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/ComputerScienceWordsAgent.java
+++ b/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/ComputerScienceWordsAgent.java
@@ -33,7 +33,6 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.SimilarityUtils;
 /**
  * This agent uses data from DBPedia to mark default words in computer science.
  *
- * @author Dominik Fuchss
  */
 public class ComputerScienceWordsAgent extends PipelineAgent {
 

--- a/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/PhraseAgent.java
+++ b/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/PhraseAgent.java
@@ -21,7 +21,6 @@ import edu.kit.kastel.mcse.ardoco.core.textextraction.TextStateImpl;
 /**
  * Agent that is responsible for looking at phrases and extracting {@link NounMapping}s from compound nouns etc.
  *
- * @author Jan Keim
  */
 public class PhraseAgent extends PipelineAgent {
     @Configurable

--- a/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/extractors/InDepArcsExtractor.java
+++ b/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/extractors/InDepArcsExtractor.java
@@ -16,8 +16,6 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.WordHelper;
 /**
  * The analyzer examines the incoming dependency arcs of the current node.
  *
- * @author Sophie Schulz
- * @author Jan Keim
  */
 public class InDepArcsExtractor extends Informant {
 

--- a/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/extractors/NounExtractor.java
+++ b/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/extractors/NounExtractor.java
@@ -17,8 +17,6 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.DataRepositoryHelper;
 /**
  * The analyzer classifies nouns.
  *
- * @author Sophie Schulz
- * @author Jan Keim
  */
 public class NounExtractor extends Informant {
     @Configurable

--- a/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/extractors/OutDepArcsExtractor.java
+++ b/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/extractors/OutDepArcsExtractor.java
@@ -16,7 +16,6 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.WordHelper;
 /**
  * The analyzer examines the outgoing arcs of the current node.
  *
- * @author Sophie
  */
 
 public class OutDepArcsExtractor extends Informant {

--- a/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/extractors/SeparatedNamesExtractor.java
+++ b/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/extractors/SeparatedNamesExtractor.java
@@ -17,7 +17,6 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.DataRepositoryHelper;
  * This analyzer classifies all nodes, containing separators, as names and adds them as mappings to the current text
  * extraction state.
  *
- * @author Sophie
  */
 
 public class SeparatedNamesExtractor extends Informant {

--- a/text-provider/src/test/java/edu/kit/kastel/mcse/ardoco/core/text/providers/SentenceTest.java
+++ b/text-provider/src/test/java/edu/kit/kastel/mcse/ardoco/core/text/providers/SentenceTest.java
@@ -13,7 +13,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.text.Sentence;
 import edu.kit.kastel.mcse.ardoco.core.text.providers.corenlp.CoreNLPProvider;
 
 /**
- * @author Jan Keim
  *
  */
 class SentenceTest {


### PR DESCRIPTION
@author tags are removed because of multiple reasons:
1. They are not consistently used.
2. Initially, they should state who created a class and is responsible. However, git and CODEOWNER file serve the same purpose without explicit stating the fact
3. Unclear how we should handle cases where changes are made to the class. When do you have to add a person as author? Is there a limit?
Due to these reasons, we abandon @author tags for now