### PR TITLE
Feature/Modify output files

### DIFF
--- a/cli/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ArDoCoCLI.java
+++ b/cli/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ArDoCoCLI.java
@@ -1,8 +1,6 @@
 /* Licensed under MIT 2022. */
 package edu.kit.kastel.mcse.ardoco.core.pipeline;
 
-import static edu.kit.kastel.mcse.ardoco.core.pipeline.ArDoCo.runAndSave;
-
 import java.io.File;
 import java.io.IOException;
 
@@ -51,18 +49,25 @@ public final class ArDoCoCLI {
         // -c : Configuration Path (only property overrides)
         // -o : Output folder
 
+        ArDoCoRunner arDoCoRunner = parseCommandLineAndBuildArDoCoRunner(args);
+        if (arDoCoRunner == null)
+            return;
+        arDoCoRunner.runArDoCo();
+    }
+
+    static ArDoCoRunner parseCommandLineAndBuildArDoCoRunner(String[] args) {
         CommandLine cmd;
         try {
             cmd = parseCommandLine(args);
         } catch (IllegalArgumentException | ParseException e) {
             logger.error(e.getMessage());
             printUsage();
-            return;
+            return null;
         }
 
         if (cmd.hasOption(CMD_HELP)) {
             printUsage();
-            return;
+            return null;
         }
 
         File inputText;
@@ -73,7 +78,7 @@ public final class ArDoCoCLI {
 
         if (!cmd.hasOption(CMD_TEXT)) {
             printUsage();
-            return;
+            return null;
         }
 
         try {
@@ -87,20 +92,17 @@ public final class ArDoCoCLI {
             outputDir = ensureDir(cmd.getOptionValue(CMD_OUT_DIR));
         } catch (IOException e) {
             logger.error(e.getMessage());
-            return;
+            return null;
         }
 
         var name = cmd.getOptionValue(CMD_NAME);
 
         if (!name.matches("\\w+")) {
             logger.error("Name does not match [A-Za-z0-9_]+");
-            return;
+            return null;
         }
-        try {
-            runAndSave(name, inputText, inputModelArchitecture, inputModelCode, additionalConfigs, outputDir);
-        } catch (Exception e) {
-            logger.error(e.getMessage(), e);
-        }
+
+        return new ArDoCoRunner(inputText, inputModelArchitecture, inputModelCode, additionalConfigs, outputDir, name);
     }
 
     private static void printUsage() {

--- a/cli/src/test/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ArDoCoCLITest.java
+++ b/cli/src/test/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ArDoCoCLITest.java
@@ -1,6 +1,8 @@
 /* Licensed under MIT 2022. */
 package edu.kit.kastel.mcse.ardoco.core.pipeline;
 
+import java.io.IOException;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -18,34 +20,44 @@ class ArDoCoCLITest {
     }
 
     @Test
-    @DisplayName("Integration Test with provided text file")
-    void pipelineWithTextIT() {
+    @DisplayName("Testing CLI with provided text file")
+    void pipelineWithTextTest() {
         String[] args = { "-n", NAME, "-ma", MODEL, "-t", TEXT, "-o", OUTPUT };
-        Assertions.assertNotNull(args);
-        ArDoCoCLI.main(args);
+        var runner = ArDoCoCLI.parseCommandLineAndBuildArDoCoRunner(args);
+
+        Assertions.assertNotNull(runner);
+
+        var additionalConfigs = ArDoCo.loadAdditionalConfigs(runner.additionalConfigs());
+        ArDoCo arDoCo = null;
+        try {
+            arDoCo = ArDoCo.defineArDoCo(runner.inputText(), runner.inputModelArchitecture(), runner.inputModelCode(), additionalConfigs);
+        } catch (IOException e) {
+            Assertions.fail("Could not define ArDoCo");
+        }
+        Assertions.assertNotNull(arDoCo);
     }
 
     @Test
-    @DisplayName("Integration Test without provided text file")
-    void pipelineWithProvidedWrongTextOntologyIT() {
+    @DisplayName("Testing CLI without provided text file")
+    void pipelineWithProvidedWrongTextTest() {
         String[] args = { "-n", NAME, "-ma", MODEL, "-o", OUTPUT };
-        Assertions.assertNotNull(args);
-        ArDoCoCLI.main(args);
+        var runner = ArDoCoCLI.parseCommandLineAndBuildArDoCoRunner(args);
+        Assertions.assertNull(runner);
     }
 
     @Test
-    @DisplayName("Integration Test with wrong text")
-    void pipelineWithNonexistentTextIT() {
+    @DisplayName("Testing CLI with wrong text")
+    void pipelineWithNonexistentTextTest() {
         String[] args = { "-n", NAME, "-ma", MODEL, "-t", "NONEXISTENT", "-o", OUTPUT };
-        Assertions.assertNotNull(args);
-        ArDoCoCLI.main(args);
+        var runner = ArDoCoCLI.parseCommandLineAndBuildArDoCoRunner(args);
+        Assertions.assertNull(runner);
     }
 
     @Test
-    @DisplayName("Integration Test with wrong model")
-    void pipelineWithNonexistentModelIT() {
+    @DisplayName("Testing CLI with wrong model")
+    void pipelineWithNonexistentModelTest() {
         String[] args = { "-n", NAME, "-ma", "NONEXISTENT", "-t", TEXT, "-o", OUTPUT };
-        Assertions.assertNotNull(args);
-        ArDoCoCLI.main(args);
+        var runner = ArDoCoCLI.parseCommandLineAndBuildArDoCoRunner(args);
+        Assertions.assertNull(runner);
     }
 }

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/ArDoCoResult.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/ArDoCoResult.java
@@ -14,6 +14,7 @@ import org.eclipse.collections.api.set.MutableSet;
 
 import edu.kit.kastel.informalin.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.api.data.connectiongenerator.ConnectionState;
+import edu.kit.kastel.mcse.ardoco.core.api.data.connectiongenerator.InstanceLink;
 import edu.kit.kastel.mcse.ardoco.core.api.data.connectiongenerator.TraceLink;
 import edu.kit.kastel.mcse.ardoco.core.api.data.inconsistency.Inconsistency;
 import edu.kit.kastel.mcse.ardoco.core.api.data.inconsistency.InconsistencyState;
@@ -32,7 +33,6 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.DataRepositoryHelper;
  * Besides accessing all data from the calculation steps, this record also provides some convenience methods to directly
  * access results such as found trace links and detected inconsistencies.
  * 
- * @param dataRepository the repository that backs the results
  */
 public record ArDoCoResult(DataRepository dataRepository) {
 
@@ -63,23 +63,35 @@ public record ArDoCoResult(DataRepository dataRepository) {
      * 
      * @return set of Trace links
      */
-    public ImmutableSet<TraceLink> getAllTraceLinks() {
+    public ImmutableList<TraceLink> getAllTraceLinks() {
         MutableSet<TraceLink> traceLinks = Sets.mutable.empty();
 
         for (var modelId : getModelIds()) {
             traceLinks.addAll(getTraceLinksForModel(modelId).castToCollection());
         }
-        return traceLinks.toImmutableSet();
+        return traceLinks.toImmutableList();
     }
 
     /**
-     * Returns the set of {@link TraceLink}s as strings in the format "ModelElementId,SentenceNo".
+     * Returns the set of {@link TraceLink}s as strings. The strings are beautified to have a human-readable format
      * 
      * @return Trace links as Strings
      */
-    public ImmutableSet<String> getAllTraceLinksAsStrings() {
-        var formatString = "%s,%d";
-        return getAllTraceLinks().collect(tl -> String.format(formatString, tl.getModelElementUid(), tl.getSentenceNumber() + 1));
+    public List<String> getAllTraceLinksAsBeautifiedStrings() {
+        return getAllTraceLinks().toSortedList(TraceLink::compareTo).collect(tl -> formatTraceLinksHumanReadable(tl));
+    }
+
+    private static String formatTraceLinksHumanReadable(TraceLink traceLink) {
+        InstanceLink instanceLink = traceLink.getInstanceLink();
+        String modelElementName = instanceLink.getModelInstance().getFullName();
+        String modelElementUid = traceLink.getModelElementUid();
+        String modelInfo = String.format("%s (%s)", modelElementName, modelElementUid);
+
+        var sentence = traceLink.getSentence();
+        int sentenceNumber = sentence.getSentenceNumberForOutput();
+        String sentenceInfo = String.format("S%3d: \"%s\"", sentenceNumber, sentence.getText());
+
+        return String.format("%-42s <--> %s", modelInfo, sentenceInfo);
     }
 
     /**

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/Confidence.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/Confidence.java
@@ -13,11 +13,6 @@ import edu.kit.kastel.informalin.framework.common.AggregationFunctions;
 import edu.kit.kastel.informalin.framework.common.ICopyable;
 import edu.kit.kastel.mcse.ardoco.core.api.agent.Claimant;
 
-/**
- *
- *
- *
- */
 public final class Confidence implements Comparable<Confidence>, ICopyable<Confidence> {
 
     private final AggregationFunctions confidenceAggregator;

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/connectiongenerator/TraceLink.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/connectiongenerator/TraceLink.java
@@ -4,6 +4,7 @@ package edu.kit.kastel.mcse.ardoco.core.api.data.connectiongenerator;
 import java.util.Objects;
 
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelInstance;
+import edu.kit.kastel.mcse.ardoco.core.api.data.text.Sentence;
 import edu.kit.kastel.mcse.ardoco.core.api.data.text.Word;
 
 /**
@@ -11,18 +12,18 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.text.Word;
  * the specific {@link ModelInstance} and {@link Word} that are used in this trace link.
  *
  */
-public class TraceLink {
+public class TraceLink implements Comparable<TraceLink> {
     private final InstanceLink instanceLink;
     private final ModelInstance modelInstance;
     private final Word word;
 
     /**
-     * Create a tracelink based on a {@link InstanceLink} and a concrete {@link ModelInstance} along with a concrete
+     * Create a trace link based on a {@link InstanceLink} and a concrete {@link ModelInstance} along with a concrete
      * {@link Word}.
      *
-     * @param instanceLink  InstanceLink of this tracelink
-     * @param modelInstance modelInstance that the tracelink points to
-     * @param word          word that the tracelink points to
+     * @param instanceLink  InstanceLink of this trace link
+     * @param modelInstance modelInstance that the trace link points to
+     * @param word          word that the trace link points to
      */
     public TraceLink(InstanceLink instanceLink, ModelInstance modelInstance, Word word) {
         this.instanceLink = instanceLink;
@@ -31,36 +32,45 @@ public class TraceLink {
     }
 
     /**
-     * Get the sentence number of the word that the tracelink is based on.
+     * Get the sentence number of the word that the trace link is based on.
      *
-     * @return sentence number of the word that the tracelink is based on.
+     * @return sentence number of the word that the trace link is based on.
      */
     public int getSentenceNumber() {
         return word.getSentenceNo();
     }
 
     /**
-     * Get the UID of the model element that the tracelink is based on.
+     * Returns the sentence of the word that the trace link is based on.
+     * 
+     * @return the sentence of the word that the trace link is based on.
+     */
+    public Sentence getSentence() {
+        return word.getSentence();
+    }
+
+    /**
+     * Get the UID of the model element that the trace link is based on.
      *
-     * @return Uid of the model element that the tracelink is based on.
+     * @return Uid of the model element that the trace link is based on.
      */
     public String getModelElementUid() {
         return modelInstance.getUid();
     }
 
     /**
-     * Get the {@link InstanceLink} that the tracelink is based on.
+     * Get the {@link InstanceLink} that the trace link is based on.
      *
-     * @return {@link InstanceLink} that the tracelink is based on.
+     * @return {@link InstanceLink} that the trace link is based on.
      */
     public InstanceLink getInstanceLink() {
         return instanceLink;
     }
 
     /**
-     * Get the probability/confidence of this tracelink
+     * Get the probability/confidence of this trace link
      *
-     * @return probability/confidence of this tracelink
+     * @return probability/confidence of this trace link
      */
     public double getProbability() {
         return instanceLink.getProbability();
@@ -84,4 +94,8 @@ public class TraceLink {
         return Objects.hash(getModelElementUid(), getSentenceNumber());
     }
 
+    @Override
+    public int compareTo(TraceLink o) {
+        return Integer.compare(this.getSentenceNumber(), o.getSentenceNumber());
+    }
 }

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/inconsistency/InconsistentSentence.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/inconsistency/InconsistentSentence.java
@@ -12,8 +12,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.text.Sentence;
  * This record represents an inconsistent sentence consisting of a sentence and all the inconsistencies that were found
  * within this sentence.
  * 
- * @param sentence        The sentence
- * @param inconsistencies the list of inconsistencies within the sentence
  */
 public record InconsistentSentence(Sentence sentence, List<Inconsistency> inconsistencies) {
 

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/output/ArDoCoResult.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/output/ArDoCoResult.java
@@ -1,5 +1,5 @@
 /* Licensed under MIT 2022. */
-package edu.kit.kastel.mcse.ardoco.core.api.data;
+package edu.kit.kastel.mcse.ardoco.core.api.output;
 
 import java.util.HashMap;
 import java.util.List;
@@ -13,6 +13,7 @@ import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.api.set.MutableSet;
 
 import edu.kit.kastel.informalin.data.DataRepository;
+import edu.kit.kastel.mcse.ardoco.core.api.data.PreprocessingData;
 import edu.kit.kastel.mcse.ardoco.core.api.data.connectiongenerator.ConnectionState;
 import edu.kit.kastel.mcse.ardoco.core.api.data.connectiongenerator.InstanceLink;
 import edu.kit.kastel.mcse.ardoco.core.api.data.connectiongenerator.TraceLink;

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/output/ArDoCoResult.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/output/ArDoCoResult.java
@@ -79,7 +79,7 @@ public record ArDoCoResult(DataRepository dataRepository) {
      * @return Trace links as Strings
      */
     public List<String> getAllTraceLinksAsBeautifiedStrings() {
-        return getAllTraceLinks().toSortedList(TraceLink::compareTo).collect(tl -> formatTraceLinksHumanReadable(tl));
+        return getAllTraceLinks().toSortedList(TraceLink::compareTo).collect(ArDoCoResult::formatTraceLinksHumanReadable);
     }
 
     private static String formatTraceLinksHumanReadable(TraceLink traceLink) {

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/CommonUtilities.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/CommonUtilities.java
@@ -1,6 +1,9 @@
 /* Licensed under MIT 2021-2022. */
 package edu.kit.kastel.mcse.ardoco.core.common.util;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -26,6 +29,8 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.textextraction.TextState;
  *
  */
 public final class CommonUtilities {
+
+    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
     private CommonUtilities() {
         throw new IllegalAccessError();
@@ -372,4 +377,7 @@ public final class CommonUtilities {
         return false;
     }
 
+    public static String getCurrentTimeAsString() {
+        return DATE_FORMATTER.format(LocalDateTime.now(ZoneId.systemDefault()));
+    }
 }

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/FilePrinter.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/FilePrinter.java
@@ -386,7 +386,7 @@ public final class FilePrinter {
         try (BufferedWriter writer = Files.newBufferedWriter(file, UTF_8)) {
             writer.write(text);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            logger.error("Could not write to file", e);
         }
     }
 
@@ -470,7 +470,7 @@ public final class FilePrinter {
     }
 
     public static void writeTraceabilityLinkRecoveryOutput(File file, ArDoCoResult arDoCoResult) {
-        Supplier<List<String>> outputExtractor = () -> arDoCoResult.getAllTraceLinksAsBeautifiedStrings();
+        Supplier<List<String>> outputExtractor = arDoCoResult::getAllTraceLinksAsBeautifiedStrings;
         writeOutput(file, "Trace Links", outputExtractor);
     }
 

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/FilePrinter.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/FilePrinter.java
@@ -73,21 +73,22 @@ public final class FilePrinter {
         var inconsistencyState = inconsistencyStates.getInconsistencyState(Metamodel.ARCHITECTURE);
 
         for (var model : getModelStatesData(data).modelIds()) {
-            var currName = name + "_" + model;
             var modelState = getModelStatesData(data).getModelState(model);
             var metaModel = modelState.getMetamodel();
             var recommendationState = getRecommendationStates(data).getRecommendationState(metaModel);
             var connectionState = getConnectionStates(data).getConnectionState(metaModel);
+            String metaModelTypeName = metaModel.toString().toLowerCase();
 
-            FilePrinter.writeModelInstancesInCsvFile(Path.of(outputDir.getAbsolutePath(), currName + "-instances-" + metaModel + ".csv").toFile(), modelState,
-                    currName);
-            FilePrinter.writeNounMappingsInCsvFile(Path.of(outputDir.getAbsolutePath(), currName + "_noun_mappings.csv").toFile(), //
+            FilePrinter.writeModelInstancesInCsvFile(Path.of(outputDir.getAbsolutePath(), name + "-instances-" + metaModelTypeName + model + ".csv").toFile(),
+                    modelState, name);
+            FilePrinter.writeNounMappingsInCsvFile(Path.of(outputDir.getAbsolutePath(), name + "_noun_mappings" + model + ".csv").toFile(), //
                     textState);
-            FilePrinter.writeTraceLinksInCsvFile(Path.of(outputDir.getAbsolutePath(), currName + "_trace_links.csv").toFile(), //
+            FilePrinter.writeTraceLinksInCsvFile(Path.of(outputDir.getAbsolutePath(), name + "_trace_links" + model + ".csv").toFile(), //
                     connectionState);
-            FilePrinter.writeStatesToFile(Path.of(outputDir.getAbsolutePath(), currName + "_states.csv").toFile(), //
+            FilePrinter.writeStatesToFile(Path.of(outputDir.getAbsolutePath(), name + "_states" + model + ".csv").toFile(), //
                     modelState, textState, recommendationState, connectionState);
-            FilePrinter.writeInconsistenciesToFile(Path.of(outputDir.getAbsolutePath(), currName + "_inconsistencies.csv").toFile(), inconsistencyState);
+            FilePrinter.writeInconsistenciesToFile(Path.of(outputDir.getAbsolutePath(), name + "_inconsistencies" + model + ".csv").toFile(),
+                    inconsistencyState);
         }
     }
 
@@ -125,7 +126,6 @@ public final class FilePrinter {
         try {
             if (file.createNewFile()) {
                 logger.info("File created: {}", file.getAbsolutePath());
-
             } else {
                 logger.info("File already exists.");
             }
@@ -253,9 +253,7 @@ public final class FilePrinter {
         dataLines.add(new String[] { "UID", "Name", "Type" });
 
         for (ModelInstance instance : modelState.getInstances()) {
-
             dataLines.add(new String[] { instance.getUid(), instance.getFullName(), instance.getFullType() });
-
         }
 
         return dataLines.toImmutable();

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/FilePrinter.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/FilePrinter.java
@@ -27,7 +27,6 @@ import org.eclipse.collections.api.list.MutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.kit.kastel.mcse.ardoco.core.api.data.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.api.data.connectiongenerator.ConnectionState;
 import edu.kit.kastel.mcse.ardoco.core.api.data.connectiongenerator.InstanceLink;
 import edu.kit.kastel.mcse.ardoco.core.api.data.connectiongenerator.TraceLink;
@@ -44,6 +43,7 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.text.Word;
 import edu.kit.kastel.mcse.ardoco.core.api.data.textextraction.MappingKind;
 import edu.kit.kastel.mcse.ardoco.core.api.data.textextraction.NounMapping;
 import edu.kit.kastel.mcse.ardoco.core.api.data.textextraction.TextState;
+import edu.kit.kastel.mcse.ardoco.core.api.output.ArDoCoResult;
 
 /**
  * The Class FilePrinter contains some helpers for stats.
@@ -414,8 +414,8 @@ public final class FilePrinter {
 
     private static Comparator<? super String> getInconsistencyStringComparator() {
         return (i, j) -> {
-            var values1 = i.split(DELIMITER);
-            var values2 = j.split(DELIMITER);
+            var values1 = i.split(DELIMITER, -1);
+            var values2 = j.split(DELIMITER, -1);
             var name1 = values1[2];
             var name2 = values2[2];
             var wordComparisonResult = name1.compareTo(name2);

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/wordsim/WordSimLoader.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/wordsim/WordSimLoader.java
@@ -3,9 +3,9 @@ package edu.kit.kastel.mcse.ardoco.core.common.util.wordsim;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +31,7 @@ public class WordSimLoader {
      *
      * @return a list of word similarity measures
      */
-    public static List<WordSimMeasure> loadUsingProperties() {
+    public static ImmutableList<WordSimMeasure> loadUsingProperties() {
         try {
             var list = new ArrayList<WordSimMeasure>();
 
@@ -66,10 +66,10 @@ public class WordSimLoader {
                 }
             }
 
-            return list;
+            return Lists.immutable.withAll(list);
         } catch (Exception e) {
             LOGGER.error("Failed to load word similarity measures", e);
-            return Collections.emptyList();
+            return Lists.immutable.empty();
         }
     }
 

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/wordsim/WordSimUtils.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/wordsim/WordSimUtils.java
@@ -1,11 +1,11 @@
 /* Licensed under MIT 2022. */
 package edu.kit.kastel.mcse.ardoco.core.common.util.wordsim;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.ImmutableList;
 import org.sqlite.SQLiteConfig;
 import org.sqlite.SQLiteOpenMode;
 
@@ -23,7 +23,7 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.wordsim.strategy.ComparisonSt
  */
 public class WordSimUtils {
 
-    private static List<WordSimMeasure> measures = WordSimLoader.loadUsingProperties();
+    private static ImmutableList<WordSimMeasure> measures = WordSimLoader.loadUsingProperties();
     private static ComparisonStrategy strategy = ComparisonStrategy.AT_LEAST_ONE;
 
     private WordSimUtils() {
@@ -36,7 +36,7 @@ public class WordSimUtils {
      * @param measures the measures to use
      */
     public static void setMeasures(Collection<WordSimMeasure> measures) {
-        WordSimUtils.measures = new ArrayList<>(measures);
+        WordSimUtils.measures = Lists.immutable.withAll(measures);
     }
 
     /**
@@ -66,7 +66,7 @@ public class WordSimUtils {
             return false;
         }
 
-        return strategy.areWordsSimilar(ctx, measures);
+        return strategy.areWordsSimilar(ctx, measures.toList());
     }
 
     private static boolean splitLengthTest(ComparisonContext ctx) {

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/wordsim/measures/fasttext/DL4JFastTextDataSource.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/wordsim/measures/fasttext/DL4JFastTextDataSource.java
@@ -41,6 +41,7 @@ public class DL4JFastTextDataSource implements WordVectorDataSource, AutoCloseab
      * @param word the word
      * @return the word vector, or {@link Optional#empty()} if no vector representation for the given word exists.
      */
+    @Override
     public Optional<float[]> getWordVector(String word) {
         Objects.requireNonNull(word);
 

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/wordsim/vector/VectorSqliteDatabase.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/wordsim/vector/VectorSqliteDatabase.java
@@ -56,6 +56,7 @@ public class VectorSqliteDatabase implements WordVectorDataSource, AutoCloseable
      * @return the vector representation, or {@link Optional#empty()} if no representation exists in the database.
      * @throws RetrieveVectorException if a database access error occurs
      */
+    @Override
     public Optional<float[]> getWordVector(String word) throws RetrieveVectorException {
         try {
             this.selectStatement.setString(1, word);

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/wordsim/vector/WordVectorSqliteImporter.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/wordsim/vector/WordVectorSqliteImporter.java
@@ -143,7 +143,7 @@ public class WordVectorSqliteImporter {
                     continue;
                 }
 
-                var parts = line.split(" ");
+                var parts = line.split(" ", -1);
                 if (parts.length - 1 != this.dimension) {
                     throw new IllegalStateException("importer has read line with invalid vector dimension: \"" + line + "\"");
                 }

--- a/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/InconsistencyStateImpl.java
+++ b/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/InconsistencyStateImpl.java
@@ -12,8 +12,6 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.inconsistency.Inconsistency;
 import edu.kit.kastel.mcse.ardoco.core.api.data.inconsistency.InconsistencyState;
 import edu.kit.kastel.mcse.ardoco.core.api.data.recommendationgenerator.RecommendedInstance;
 
-/**
- */
 public class InconsistencyStateImpl extends AbstractState implements InconsistencyState {
 
     private transient MutableList<RecommendedInstance> recommendedInstances;

--- a/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/MissingElementInconsistencyCandidate.java
+++ b/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/MissingElementInconsistencyCandidate.java
@@ -54,13 +54,9 @@ public class MissingElementInconsistencyCandidate {
         if (this == obj) {
             return true;
         }
-        if (obj == null) {
+        if (!(obj instanceof MissingElementInconsistencyCandidate other)) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        MissingElementInconsistencyCandidate other = (MissingElementInconsistencyCandidate) obj;
         return Objects.equals(recommendedInstance, other.recommendedInstance);
     }
 

--- a/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/informants/OccasionFilter.java
+++ b/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/informants/OccasionFilter.java
@@ -27,8 +27,9 @@ public class OccasionFilter extends Filter {
         super("OccasionFilter", dataRepository);
     }
 
+    @Override
     protected void filterRecommendedInstances(InconsistencyState inconsistencyState) {
-        var filteredRecommendedInstances = Lists.mutable.<RecommendedInstance> empty();
+        var filteredRecommendedInstances = Lists.mutable.<RecommendedInstance>empty();
         var recommendedInstances = inconsistencyState.getRecommendedInstances();
 
         for (var recommendedInstance : recommendedInstances) {

--- a/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/informants/RecommendedInstanceProbabilityFilter.java
+++ b/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/informants/RecommendedInstanceProbabilityFilter.java
@@ -45,8 +45,9 @@ public class RecommendedInstanceProbabilityFilter extends Filter {
     /**
      * Filter RecommendedInstances based on various heuristics. First, filter unlikely ones (low probability).
      */
+    @Override
     protected void filterRecommendedInstances(InconsistencyState inconsistencyState) {
-        var filteredRecommendedInstances = Lists.mutable.<RecommendedInstance> empty();
+        var filteredRecommendedInstances = Lists.mutable.<RecommendedInstance>empty();
         var recommendedInstances = inconsistencyState.getRecommendedInstances();
 
         if (dynamicThreshold) {
@@ -110,8 +111,7 @@ public class RecommendedInstanceProbabilityFilter extends Filter {
         var highestTypeProbability = getHighestTypeProbability(recommendedInstance.getTypeMappings());
         var highestNameProbability = getHighestNameProbability(recommendedInstance.getTypeMappings());
 
-        return highestTypeProbability > thresholdNameAndTypeProbability && highestNameProbability > thresholdNameAndTypeProbability
-                || highestTypeProbability > thresholdNameOrTypeProbability || highestNameProbability > thresholdNameOrTypeProbability;
+        return highestTypeProbability > thresholdNameAndTypeProbability && highestNameProbability > thresholdNameAndTypeProbability || highestTypeProbability > thresholdNameOrTypeProbability || highestNameProbability > thresholdNameOrTypeProbability;
 
     }
 

--- a/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/MissingModelInstanceInconsistency.java
+++ b/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/MissingModelInstanceInconsistency.java
@@ -14,11 +14,11 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.inconsistency.TextInconsistency;
 public record MissingModelInstanceInconsistency(String name, int sentence, double confidence) implements TextInconsistency {
 
     private static final String INCONSISTENCY_TYPE_NAME = "MissingModelInstance";
-    private static final String REASON_FORMAT_STRING = "Text indicates that \"%s\" should be contained in the model(s) but could not be found. (confidence: %.2f)";
 
     @Override
     public String getReason() {
-        return String.format(Locale.US, REASON_FORMAT_STRING, name, confidence);
+        return String.format(Locale.US, "Text indicates that \"%s\" should be contained in the model(s) but could not be found. (confidence: %.2f)", name,
+                confidence);
     }
 
     @Override

--- a/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/MissingTextForModelElementInconsistency.java
+++ b/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/MissingTextForModelElementInconsistency.java
@@ -10,12 +10,8 @@ import org.eclipse.collections.api.factory.Lists;
 import edu.kit.kastel.mcse.ardoco.core.api.data.inconsistency.Inconsistency;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelInstance;
 
-/**
- */
 public class MissingTextForModelElementInconsistency implements Inconsistency {
     private static final String INCONSISTENCY_TYPE_NAME = "MissingTextForModelElement";
-
-    private static final String REASON_FORMAT_STRING = "Model contains an Instance \"%s\" (type: \"%s\")  that seems to be undocumented.";
 
     private final ModelInstance instance;
 
@@ -30,7 +26,8 @@ public class MissingTextForModelElementInconsistency implements Inconsistency {
 
     @Override
     public String getReason() {
-        return String.format(Locale.US, REASON_FORMAT_STRING, instance.getFullName(), instance.getFullType());
+        return String.format(Locale.US, "Model contains an Instance \"%s\" (type: \"%s\")  that seems to be undocumented.", instance.getFullName(), instance
+                .getFullType());
     }
 
     @Override
@@ -53,10 +50,9 @@ public class MissingTextForModelElementInconsistency implements Inconsistency {
         if (this == obj) {
             return true;
         }
-        if (obj == null || getClass() != obj.getClass()) {
+        if (!(obj instanceof MissingTextForModelElementInconsistency other)) {
             return false;
         }
-        var other = (MissingTextForModelElementInconsistency) obj;
         return Objects.equals(instance, other.instance);
     }
 

--- a/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/NameInconsistency.java
+++ b/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/NameInconsistency.java
@@ -17,8 +17,6 @@ public class NameInconsistency implements TextInconsistency {
 
     private static final String INCONSISTENCY_TYPE_NAME = "NameInconsistency";
 
-    private static final String REASON_FORMAT_STRING = "Inconsistent naming in trace link between textual occurence \"%s\" and model element \"%s\" (%s)";
-
     private final ModelInstance modelInstance;
     private final Word word;
     private final int sentenceNo;
@@ -34,7 +32,8 @@ public class NameInconsistency implements TextInconsistency {
         String textOccurrence = word.getText();
         String modelOccurrence = modelInstance.getFullName();
         String uid = modelInstance.getUid();
-        return String.format(Locale.US, REASON_FORMAT_STRING, textOccurrence, modelOccurrence, uid);
+        return String.format(Locale.US, "Inconsistent naming in trace link between textual occurence \"%s\" and model element \"%s\" (%s)", textOccurrence,
+                modelOccurrence, uid);
     }
 
     @Override
@@ -70,13 +69,9 @@ public class NameInconsistency implements TextInconsistency {
         if (this == obj) {
             return true;
         }
-        if (obj == null) {
+        if (!(obj instanceof NameInconsistency other)) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        NameInconsistency other = (NameInconsistency) obj;
         return Objects.equals(modelInstance, other.modelInstance) && Objects.equals(word, other.word);
     }
 

--- a/inconsistency-detection/src/test/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/AbstractInconsistencyTypeTest.java
+++ b/inconsistency-detection/src/test/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/types/AbstractInconsistencyTypeTest.java
@@ -142,10 +142,9 @@ public abstract class AbstractInconsistencyTypeTest {
             if (this == obj) {
                 return true;
             }
-            if (obj == null || getClass() != obj.getClass()) {
+            if (!(obj instanceof DummyWord other)) {
                 return false;
             }
-            var other = (DummyWord) obj;
             return getPosition() == other.getPosition() && getSentence() == other.getSentence() && Objects.equals(getText(), other.getText());
         }
     }

--- a/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/model/ModelInstanceImpl.java
+++ b/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/model/ModelInstanceImpl.java
@@ -128,10 +128,9 @@ public class ModelInstanceImpl implements ModelInstance {
         if (this == obj) {
             return true;
         }
-        if (obj == null || getClass() != obj.getClass()) {
+        if (!(obj instanceof ModelInstanceImpl other)) {
             return false;
         }
-        ModelInstanceImpl other = (ModelInstanceImpl) obj;
         return Objects.equals(fullName, other.fullName) && Objects.equals(fullType, other.fullType) && Objects.equals(uid, other.uid);
     }
 

--- a/pipeline/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ArDoCo.java
+++ b/pipeline/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ArDoCo.java
@@ -131,8 +131,7 @@ public final class ArDoCo extends Pipeline {
     private static File getOutputFile(String name, File outputDir, String prefix) {
         var filename = prefix + name + ".txt";
         var filepath = outputDir.toPath().resolve(filename);
-        var file = filepath.toFile();
-        return file;
+        return filepath.toFile();
     }
 
     public static InconsistencyChecker getInconsistencyChecker(Map<String, String> additionalConfigs, DataRepository dataRepository) {

--- a/pipeline/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ArDoCo.java
+++ b/pipeline/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ArDoCo.java
@@ -101,8 +101,7 @@ public final class ArDoCo extends Pipeline {
         return arDoCoResult;
     }
 
-    private static ArDoCo defineArDoCo(File inputText, File inputArchitectureModel, File inputCodeModel, Map<String, String> additionalConfigs)
-            throws IOException {
+    static ArDoCo defineArDoCo(File inputText, File inputArchitectureModel, File inputCodeModel, Map<String, String> additionalConfigs) throws IOException {
         var arDoCo = new ArDoCo();
         var dataRepository = arDoCo.getDataRepository();
 

--- a/pipeline/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ArDoCo.java
+++ b/pipeline/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ArDoCo.java
@@ -17,8 +17,8 @@ import org.slf4j.LoggerFactory;
 
 import edu.kit.kastel.informalin.data.DataRepository;
 import edu.kit.kastel.informalin.pipeline.Pipeline;
-import edu.kit.kastel.mcse.ardoco.core.api.data.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelConnector;
+import edu.kit.kastel.mcse.ardoco.core.api.output.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.common.util.FilePrinter;
 import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.ConnectionGenerator;
 import edu.kit.kastel.mcse.ardoco.core.inconsistency.InconsistencyChecker;

--- a/pipeline/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ArDoCoRunner.java
+++ b/pipeline/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ArDoCoRunner.java
@@ -1,0 +1,33 @@
+/* Licensed under MIT 2022. */
+package edu.kit.kastel.mcse.ardoco.core.pipeline;
+
+import static edu.kit.kastel.mcse.ardoco.core.pipeline.ArDoCo.runAndSave;
+
+import java.io.File;
+import java.util.Objects;
+
+import edu.kit.kastel.mcse.ardoco.core.api.output.ArDoCoResult;
+
+record ArDoCoRunner(File inputText, File inputModelArchitecture, File inputModelCode, File additionalConfigs, File outputDir, String name) {
+
+    ArDoCoResult runArDoCo() {
+        return runAndSave(name, inputText, inputModelArchitecture, inputModelCode, additionalConfigs, outputDir);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this)
+            return true;
+        if (!(obj instanceof ArDoCoRunner other))
+            return false;
+        return Objects.equals(this.inputText, other.inputText) && Objects.equals(this.inputModelArchitecture, other.inputModelArchitecture) && Objects.equals(
+                this.inputModelCode, other.inputModelCode) && Objects.equals(this.additionalConfigs, other.additionalConfigs) && Objects.equals(this.outputDir,
+                        other.outputDir) && Objects.equals(this.name, other.name);
+    }
+
+    @Override
+    public String toString() {
+        return "ArDoCoRunArguments[" + "inputText=" + inputText + ", " + "inputModelArchitecture=" + inputModelArchitecture + ", " + "inputModelCode=" + inputModelCode + ", " + "additionalConfigs=" + additionalConfigs + ", " + "outputDir=" + outputDir + ", " + "name=" + name + ']';
+    }
+
+}

--- a/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/RecommendedInstanceImpl.java
+++ b/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/RecommendedInstanceImpl.java
@@ -243,10 +243,9 @@ public class RecommendedInstanceImpl implements RecommendedInstance, Claimant {
         if (this == obj) {
             return true;
         }
-        if (obj == null || getClass() != obj.getClass()) {
+        if (!(obj instanceof RecommendedInstanceImpl other)) {
             return false;
         }
-        var other = (RecommendedInstanceImpl) obj;
         return Objects.equals(name, other.name) && Objects.equals(type, other.type);
     }
 

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/architecture/ArchitectureTest.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/architecture/ArchitectureTest.java
@@ -23,7 +23,7 @@ public class ArchitectureTest {
             .haveSimpleName("ModelInstance")
             .should()
             .onlyHaveDependentClassesThat()
-            .resideInAnyPackage("..model..", "..connectiongenerator..", "..inconsistency..", "..pipeline..", "..common..", "..tests..");
+            .resideInAnyPackage("..model..", "..connectiongenerator..", "..inconsistency..", "..pipeline..", "..common..", "..output..", "..tests..");
 
     @ArchTest
     public static final ArchRule linksOnlyAfterConnectionGenerator = classes().that()
@@ -36,7 +36,7 @@ public class ArchitectureTest {
     public static final ArchRule usingLinkAsNamingOnlyInConnectionGenerator = classes().that()
             .haveSimpleNameEndingWith("Link")
             .should()
-            .resideInAnyPackage("..connectiongenerator..", "..tests..");
+            .resideInAnyPackage("..connectiongenerator..", "..output..", "..tests..");
 
     @ArchTest
     public static final ArchRule inconsistencyOnlyAfterInconsistencyDetection = classes().that()

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/GoldStandard.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/GoldStandard.java
@@ -3,16 +3,21 @@ package edu.kit.kastel.mcse.ardoco.core.tests.eval;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelConnector;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelInstance;
 
 public class GoldStandard {
+    private Logger logger = LoggerFactory.getLogger(GoldStandard.class);
+
     private File goldStandard;
     private ModelConnector model;
 
@@ -25,7 +30,7 @@ public class GoldStandard {
     }
 
     private void load() {
-        try (Scanner scan = new Scanner(goldStandard)) {
+        try (Scanner scan = new Scanner(goldStandard, StandardCharsets.UTF_8.name())) {
             while (scan.hasNextLine()) {
                 String line = scan.nextLine();
                 if (line == null || line.isBlank() || line.contains("modelElementID")) {
@@ -33,7 +38,7 @@ public class GoldStandard {
                     continue;
                 }
 
-                String[] idXline = line.strip().split(",");
+                String[] idXline = line.strip().split(",", -1);
                 ModelInstance instance = model.getInstances().select(i -> i.getUid().equals(idXline[0])).getFirst();
                 if (instance == null) {
                     System.err.println("No instance found for id \"" + idXline[0] + "\"");
@@ -46,7 +51,7 @@ public class GoldStandard {
                 sentence2instance.get(sentence).add(instance);
             }
         } catch (FileNotFoundException e) {
-            e.printStackTrace();
+            logger.warn(e.getMessage(), e.getCause());
         }
     }
 

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/Project.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/Project.java
@@ -3,9 +3,6 @@ package edu.kit.kastel.mcse.ardoco.core.tests.eval;
 
 import java.io.File;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelConnector;
 
 /**
@@ -43,13 +40,11 @@ public enum Project {
             new EvaluationResults(.000, .000, .272) //
     );
 
-    private static final Logger logger = LoggerFactory.getLogger(Project.class);
     private final String model;
     private final String textFile;
     private final String goldStandard;
     private final EvaluationResults expectedTraceLinkResults;
     private final EvaluationResults expectedInconsistencyResults;
-    private volatile ModelConnector modelConnector = null;
 
     Project(String model, String textFile, String goldStandard, EvaluationResults expectedTraceLinkResults, EvaluationResults expectedInconsistencyResults) {
         this.model = model;

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/InconsistencyDetectionEvaluationIT.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/InconsistencyDetectionEvaluationIT.java
@@ -25,9 +25,9 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.kit.kastel.mcse.ardoco.core.api.data.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.api.data.inconsistency.InconsistentSentence;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelInstance;
+import edu.kit.kastel.mcse.ardoco.core.api.output.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.common.util.FilePrinter;
 import edu.kit.kastel.mcse.ardoco.core.inconsistency.types.MissingModelInstanceInconsistency;
 import edu.kit.kastel.mcse.ardoco.core.model.PcmXMLModelConnector;

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/InconsistencyDetectionEvaluationIT.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/InconsistencyDetectionEvaluationIT.java
@@ -242,7 +242,7 @@ class InconsistencyDetectionEvaluationIT {
         var detailedOutputBuilder = outputs.getTwo();
 
         Path outputPath = Path.of(OUTPUT);
-        Path idEvalPath = outputPath.resolve("id_eval");
+        Path idEvalPath = outputPath.resolve("ardoco_eval_id");
         try {
             Files.createDirectories(outputPath);
             Files.createDirectories(idEvalPath);

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/InconsistencyDetectionEvaluationIT.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/InconsistencyDetectionEvaluationIT.java
@@ -1,14 +1,10 @@
 /* Licensed under MIT 2021-2022. */
 package edu.kit.kastel.mcse.ardoco.core.tests.integration;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import edu.kit.kastel.mcse.ardoco.core.api.data.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.api.data.inconsistency.InconsistentSentence;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelInstance;
+import edu.kit.kastel.mcse.ardoco.core.common.util.FilePrinter;
 import edu.kit.kastel.mcse.ardoco.core.inconsistency.types.MissingModelInstanceInconsistency;
 import edu.kit.kastel.mcse.ardoco.core.model.PcmXMLModelConnector;
 import edu.kit.kastel.mcse.ardoco.core.tests.TestUtil;
@@ -53,11 +50,13 @@ import edu.kit.kastel.mcse.ardoco.core.tests.integration.inconsistencyhelper.Hol
  */
 class InconsistencyDetectionEvaluationIT {
     private static final Logger logger = LoggerFactory.getLogger(InconsistencyDetectionEvaluationIT.class);
+
     private static final String OUTPUT = "src/test/resources/testout";
+    public static final String DIRECTORY_NAME = "ardoco_eval_id";
 
     private static final OverallResultsCalculator OVERALL_RESULTS_CALCULATOR = new OverallResultsCalculator();
     private static final OverallResultsCalculator OVERALL_RESULT_CALCULATOR_BASELINE = new OverallResultsCalculator();
-    public static final String LINE_SEPARATOR = System.lineSeparator();
+    private static final String LINE_SEPARATOR = System.lineSeparator();
     private static boolean ranBaseline = false;
     private static Map<Project, ImmutableList<InconsistentSentence>> inconsistentSentencesPerProject = new HashMap<>();
 
@@ -94,7 +93,7 @@ class InconsistencyDetectionEvaluationIT {
     }
 
     private static void writeOutput(EvaluationResults weightedResults, EvaluationResults macroResults) throws IOException {
-        var evalDir = Path.of(OUTPUT).resolve("id_eval");
+        var evalDir = Path.of(OUTPUT).resolve(DIRECTORY_NAME);
         Files.createDirectories(evalDir);
         var outputFile = evalDir.resolve("base_results.md");
 
@@ -242,7 +241,7 @@ class InconsistencyDetectionEvaluationIT {
         var detailedOutputBuilder = outputs.getTwo();
 
         Path outputPath = Path.of(OUTPUT);
-        Path idEvalPath = outputPath.resolve("ardoco_eval_id");
+        Path idEvalPath = outputPath.resolve(DIRECTORY_NAME);
         try {
             Files.createDirectories(outputPath);
             Files.createDirectories(idEvalPath);
@@ -251,12 +250,12 @@ class InconsistencyDetectionEvaluationIT {
         }
 
         String projectFileName = "inconsistencies_" + project.name().toLowerCase() + ".txt";
-        var filename = outputPath.resolve(projectFileName).toFile().getAbsolutePath();
-        writeToFile(filename, outputBuilder.toString());
+        var filename = idEvalPath.resolve(projectFileName).toFile().getAbsolutePath();
+        FilePrinter.writeToFile(filename, outputBuilder.toString());
 
         String detailedProjectFileName = "detailed_" + projectFileName;
         var detailedFilename = idEvalPath.resolve(detailedProjectFileName).toFile().getAbsolutePath();
-        writeToFile(detailedFilename, detailedOutputBuilder.toString());
+        FilePrinter.writeToFile(detailedFilename, detailedOutputBuilder.toString());
     }
 
     private static Pair<StringBuilder, StringBuilder> createOutput(Project project, List<ExplicitEvaluationResults<String>> results,
@@ -267,14 +266,6 @@ class InconsistencyDetectionEvaluationIT {
         outputBuilder.append(getOverallResultsString(resultCalculator));
         var detailedOutputBuilder = resultCalculatorStringBuilderPair.getTwo();
         return Tuples.pair(outputBuilder, detailedOutputBuilder);
-    }
-
-    private static void writeToFile(String filename, String text) {
-        try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(filename), UTF_8)) {
-            writer.write(text);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private static String getOverallResultsString(ResultCalculator resultCalculator) {

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceabilityLinkRecoveryEvaluationIT.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceabilityLinkRecoveryEvaluationIT.java
@@ -32,6 +32,7 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelExtractionState;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelInstance;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelStates;
 import edu.kit.kastel.mcse.ardoco.core.api.data.text.Sentence;
+import edu.kit.kastel.mcse.ardoco.core.common.util.FilePrinter;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.ArDoCo;
 import edu.kit.kastel.mcse.ardoco.core.tests.TestUtil;
 import edu.kit.kastel.mcse.ardoco.core.tests.eval.EvaluationResults;
@@ -54,6 +55,7 @@ class TraceabilityLinkRecoveryEvaluationIT {
     private static final Logger logger = LoggerFactory.getLogger(TraceabilityLinkRecoveryEvaluationIT.class);
 
     private static final String OUTPUT = "src/test/resources/testout";
+    private static final Path OUTPUT_PATH = Path.of(OUTPUT);
     private static final String ADDITIONAL_CONFIG = null;
     private static final List<TLProjectEvalResult> RESULTS = new ArrayList<>();
     private static final Map<Project, ArDoCoResult> DATA_MAP = new HashMap<>();
@@ -121,11 +123,7 @@ class TraceabilityLinkRecoveryEvaluationIT {
     @DisplayName("Evaluate TLR (Text-based)")
     @ParameterizedTest(name = "Evaluating {0} (Text)")
     @EnumSource(value = Project.class)
-    void compareTraceLinksTextIT(Project project) {
-        compare(project);
-    }
-
-    private void compare(Project project) {
+    void evaluateTraceLinkRecoveryIT(Project project) {
         var name = project.name().toLowerCase();
         inputModel = project.getModelFile();
         inputText = project.getTextFile();
@@ -134,16 +132,20 @@ class TraceabilityLinkRecoveryEvaluationIT {
         ArDoCoResult arDoCoResult = ArDoCo.runAndSave("test_" + name, inputText, inputModel, null, additionalConfigs, outputDir);
         Assertions.assertNotNull(arDoCoResult);
 
-        var data = arDoCoResult.dataRepository();
-        Assertions.assertNotNull(data);
+        // calculate results and compare to expected results
+        checkResults(project, name, arDoCoResult);
+
+        writeDetailedOutput(project, arDoCoResult);
+    }
+
+    private void checkResults(Project project, String name, ArDoCoResult arDoCoResult) {
         var modelIds = arDoCoResult.getModelIds();
-        Assertions.assertEquals(1, modelIds.size());
         var modelId = modelIds.stream().findFirst().orElseThrow();
         var model = arDoCoResult.getModelState(modelId);
 
-        // calculate results and compare to expected results
         var results = calculateResults(project, arDoCoResult, model);
         var expectedResults = project.getExpectedTraceLinkResults();
+        var data = arDoCoResult.dataRepository();
 
         if (logger.isInfoEnabled()) {
             TestUtil.logResultsWithExpected(logger, name, results, expectedResults);
@@ -169,7 +171,39 @@ class TraceabilityLinkRecoveryEvaluationIT {
                         .getRecall() + " is below the expected minimum value " + expectedResults.getRecall()), //
                 () -> Assertions.assertTrue(results.getF1() >= expectedResults.getF1(), "F1 " + results
                         .getF1() + " is below the expected minimum value " + expectedResults.getF1()));
+    }
 
+    private static void writeDetailedOutput(Project project, ArDoCoResult arDoCoResult) {
+        String name = project.name().toLowerCase();
+        var path = OUTPUT_PATH.resolve(name);
+        try {
+            Files.createDirectories(path);
+        } catch (IOException e) {
+            logger.warn("Could not create directories.", e);
+        }
+        FilePrinter.printResultsInFiles(path, name, arDoCoResult);
+    }
+
+    private EvaluationResults calculateResults(Project project, ArDoCoResult arDoCoResult, ModelExtractionState modelState) {
+        String modelId = modelState.getModelId();
+        var traceLinks = arDoCoResult.getTraceLinksForModelAsStrings(modelId);
+        logger.info("Found {} trace links", traceLinks.size());
+
+        var goldStandard = getGoldStandard(project);
+
+        return TestUtil.compare(traceLinks.toSet(), goldStandard);
+    }
+
+    private List<String> getGoldStandard(Project project) {
+        var path = Paths.get(project.getGoldStandardFile().toURI());
+        List<String> goldLinks = Lists.mutable.empty();
+        try {
+            goldLinks = Files.readAllLines(path);
+        } catch (IOException e) {
+            logger.error(e.getMessage(), e);
+        }
+        goldLinks.remove(0);
+        return goldLinks;
     }
 
     private void printDetailedDebug(ExplicitEvaluationResults<?> results, DataRepository data) {
@@ -224,25 +258,4 @@ class TraceabilityLinkRecoveryEvaluationIT {
         return outputList;
     }
 
-    private EvaluationResults calculateResults(Project project, ArDoCoResult arDoCoResult, ModelExtractionState modelState) {
-        String modelId = modelState.getModelId();
-        var traceLinks = arDoCoResult.getTraceLinksForModelAsStrings(modelId);
-        logger.info("Found {} trace links", traceLinks.size());
-
-        var goldStandard = getGoldStandard(project);
-
-        return TestUtil.compare(traceLinks.toSet(), goldStandard);
-    }
-
-    private List<String> getGoldStandard(Project project) {
-        var path = Paths.get(project.getGoldStandardFile().toURI());
-        List<String> goldLinks = Lists.mutable.empty();
-        try {
-            goldLinks = Files.readAllLines(path);
-        } catch (IOException e) {
-            logger.error(e.getMessage(), e);
-        }
-        goldLinks.remove(0);
-        return goldLinks;
-    }
 }

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceabilityLinkRecoveryEvaluationIT.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceabilityLinkRecoveryEvaluationIT.java
@@ -26,12 +26,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.kit.kastel.informalin.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.api.data.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.api.data.PreprocessingData;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelExtractionState;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelInstance;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelStates;
 import edu.kit.kastel.mcse.ardoco.core.api.data.text.Sentence;
+import edu.kit.kastel.mcse.ardoco.core.api.output.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.common.util.FilePrinter;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.ArDoCo;
 import edu.kit.kastel.mcse.ardoco.core.tests.TestUtil;

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceabilityLinkRecoveryEvaluationIT.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceabilityLinkRecoveryEvaluationIT.java
@@ -86,7 +86,7 @@ class TraceabilityLinkRecoveryEvaluationIT {
         }
 
         if (detailedDebug) {
-            var evalDir = Path.of(OUTPUT).resolve("tl_eval");
+            var evalDir = Path.of(OUTPUT).resolve("ardoco_eval_tl");
 
             try {
                 Files.createDirectories(evalDir);

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/inconsistencyhelper/HoldBackRunResultsProducer.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/inconsistencyhelper/HoldBackRunResultsProducer.java
@@ -10,9 +10,9 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 
 import edu.kit.kastel.informalin.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.api.data.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.api.data.PreprocessingData;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelInstance;
+import edu.kit.kastel.mcse.ardoco.core.api.output.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.model.ModelProvider;
 import edu.kit.kastel.mcse.ardoco.core.model.PcmXMLModelConnector;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.ArDoCo;

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/TLProjectEvalResult.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/TLProjectEvalResult.java
@@ -38,10 +38,10 @@ public class TLProjectEvalResult extends EvaluationResults implements Comparable
     private final List<TestLink> falseNegatives = new ArrayList<>();
 
     public TLProjectEvalResult(Project project, DataRepository data) throws IOException {
-        this(project, getTraceLinks(project, data), TLGoldStandardFile.loadLinks(project));
+        this(project, getTraceLinks(data), TLGoldStandardFile.loadLinks(project));
     }
 
-    private static List<TestLink> getTraceLinks(Project project, DataRepository data) {
+    private static List<TestLink> getTraceLinks(DataRepository data) {
         var traceLinks = Lists.mutable.<TestLink>empty();
         var connectionStates = data.getData(ConnectionStates.ID, ConnectionStates.class).orElseThrow();
         var modelStates = data.getData(ModelStates.ID, ModelStates.class).orElseThrow();

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/files/TLDiffFile.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/files/TLDiffFile.java
@@ -10,7 +10,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import edu.kit.kastel.mcse.ardoco.core.api.data.ArDoCoResult;
+import edu.kit.kastel.mcse.ardoco.core.api.output.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.common.util.CommonUtilities;
 import edu.kit.kastel.mcse.ardoco.core.tests.eval.Project;
 import edu.kit.kastel.mcse.ardoco.core.tests.integration.tlrhelper.TLProjectEvalResult;

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/files/TLDiffFile.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/files/TLDiffFile.java
@@ -6,14 +6,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.text.DecimalFormat;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 import edu.kit.kastel.mcse.ardoco.core.api.data.ArDoCoResult;
+import edu.kit.kastel.mcse.ardoco.core.common.util.CommonUtilities;
 import edu.kit.kastel.mcse.ardoco.core.tests.eval.Project;
 import edu.kit.kastel.mcse.ardoco.core.tests.integration.tlrhelper.TLProjectEvalResult;
 import edu.kit.kastel.mcse.ardoco.core.tests.integration.tlrhelper.TestLink;
@@ -24,7 +22,6 @@ import edu.kit.kastel.mcse.ardoco.core.tests.integration.tlrhelper.TestLink;
 public class TLDiffFile {
 
     private static final DecimalFormat NUMBER_FORMAT = new DecimalFormat("+##0.00%;-##0.00%");
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
     private static final String LINE_SEPARATOR = System.lineSeparator();
 
     private TLDiffFile() {
@@ -49,7 +46,7 @@ public class TLDiffFile {
 
         var builder = new StringBuilder();
 
-        builder.append("Time of evaluation: `").append(DATE_FORMATTER.format(LocalDateTime.now(ZoneId.systemDefault()))).append("`");
+        builder.append("Time of evaluation: `").append(CommonUtilities.getCurrentTimeAsString()).append("`");
         builder.append(LINE_SEPARATOR);
 
         // Append average differences in precision, recall, f1

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/files/TLLogFile.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/files/TLLogFile.java
@@ -6,11 +6,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.text.DecimalFormat;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+import edu.kit.kastel.mcse.ardoco.core.common.util.CommonUtilities;
 import edu.kit.kastel.mcse.ardoco.core.tests.integration.tlrhelper.TLProjectEvalResult;
 
 /**
@@ -19,7 +17,6 @@ import edu.kit.kastel.mcse.ardoco.core.tests.integration.tlrhelper.TLProjectEval
 public class TLLogFile {
     private static final String LINE_SEPARATOR = System.lineSeparator();
     private static final DecimalFormat NUMBER_FORMAT = new DecimalFormat("##0.00%");
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
     private TLLogFile() {
         throw new IllegalAccessError("This constructor should not be called!");
@@ -36,7 +33,7 @@ public class TLLogFile {
         var sortedResults = results.stream().sorted().toList();
         var builder = new StringBuilder();
 
-        builder.append("- `").append(DATE_FORMATTER.format(LocalDateTime.now(ZoneId.systemDefault()))).append("` ");
+        builder.append("- `").append(CommonUtilities.getCurrentTimeAsString()).append("` ");
 
         // calc average
         double avgPrecision = results.stream().mapToDouble(TLProjectEvalResult::getPrecision).average().orElse(Double.NaN);

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/files/TLModelFile.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/files/TLModelFile.java
@@ -7,8 +7,8 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Map;
 
-import edu.kit.kastel.mcse.ardoco.core.api.data.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelInstance;
+import edu.kit.kastel.mcse.ardoco.core.api.output.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.tests.eval.Project;
 
 /**

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/files/TLSentenceFile.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/files/TLSentenceFile.java
@@ -9,8 +9,8 @@ import java.util.Map;
 
 import org.eclipse.collections.api.list.ImmutableList;
 
-import edu.kit.kastel.mcse.ardoco.core.api.data.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.api.data.text.Sentence;
+import edu.kit.kastel.mcse.ardoco.core.api.output.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.tests.eval.Project;
 
 /**

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/files/TLSummaryFile.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/files/TLSummaryFile.java
@@ -6,9 +6,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.text.DecimalFormat;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +13,7 @@ import java.util.Map;
 import edu.kit.kastel.mcse.ardoco.core.api.data.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelExtractionState;
 import edu.kit.kastel.mcse.ardoco.core.api.data.text.Text;
+import edu.kit.kastel.mcse.ardoco.core.common.util.CommonUtilities;
 import edu.kit.kastel.mcse.ardoco.core.tests.TestUtil;
 import edu.kit.kastel.mcse.ardoco.core.tests.eval.Project;
 import edu.kit.kastel.mcse.ardoco.core.tests.integration.tlrhelper.TLProjectEvalResult;
@@ -26,7 +24,6 @@ import edu.kit.kastel.mcse.ardoco.core.tests.integration.tlrhelper.TestLink;
  */
 public class TLSummaryFile {
     private static final DecimalFormat NUMBER_FORMAT = new DecimalFormat("##0.00%");
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
     private static final String LINE_SEPARATOR = System.lineSeparator();
 
     private TLSummaryFile() {
@@ -45,7 +42,7 @@ public class TLSummaryFile {
         var sortedResults = results.stream().sorted().toList();
         var builder = new StringBuilder();
 
-        builder.append("Time of evaluation: `").append(DATE_FORMATTER.format(LocalDateTime.now(ZoneId.systemDefault()))).append("`");
+        builder.append("Time of evaluation: `").append(CommonUtilities.getCurrentTimeAsString()).append("`");
         builder.append(LINE_SEPARATOR);
 
         appendOverallResults(sortedResults, builder);

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/files/TLSummaryFile.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/tlrhelper/files/TLSummaryFile.java
@@ -10,9 +10,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import edu.kit.kastel.mcse.ardoco.core.api.data.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelExtractionState;
 import edu.kit.kastel.mcse.ardoco.core.api.data.text.Text;
+import edu.kit.kastel.mcse.ardoco.core.api.output.ArDoCoResult;
 import edu.kit.kastel.mcse.ardoco.core.common.util.CommonUtilities;
 import edu.kit.kastel.mcse.ardoco.core.tests.TestUtil;
 import edu.kit.kastel.mcse.ardoco.core.tests.eval.Project;

--- a/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/ComputerScienceWordsAgent.java
+++ b/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/ComputerScienceWordsAgent.java
@@ -171,7 +171,7 @@ public class ComputerScienceWordsAgent extends PipelineAgent {
         loadStandardGlossary(result);
         result.addAll(additionalWords);
         // Remove after bracket (
-        result = result.stream().map(e -> e.split("\\(")[0].trim()).collect(Collectors.toSet());
+        result = result.stream().map(e -> e.split("\\(", -1)[0].trim()).collect(Collectors.toSet());
         return Lists.immutable.withAll(result.stream().map(w -> w.trim().toLowerCase()).toList());
     }
 

--- a/text-extraction/src/test/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/ComputerScienceWordsAgentTest.java
+++ b/text-extraction/src/test/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/ComputerScienceWordsAgentTest.java
@@ -66,7 +66,7 @@ class ComputerScienceWordsAgentTest implements Claimant {
     }
 
     private List<Word> wordToListOfWord(String word) {
-        var words = word.split("\\s+");
+        var words = word.split("\\s+", -1);
         List<Word> wordsList = new ArrayList<>();
         for (int i = 0; i < words.length; i++) {
             wordsList.add(new MyWord(words[i], i));


### PR DESCRIPTION
This PR updates what output is written (and where).

Usual runs of ArDoCo write human-readable output files. All other information is conveyed via the return value of calling the public static methods of the ArDoCo class like `run(String name, File inputText, File inputArchitectureModel, File additionalConfigs)` or `runAndSave(String name, File inputText, File inputArchitectureModel, File inputCodeModel, File additionalConfigsFile, File outputDir)`.

Detailed output is shifted to the Integration Tests (mostly to the TLR one due to its simpler nature). There, the output is stored within folders to separate the outputs from different projects.