### PR TITLE
Feature/Consider project name

### DIFF
--- a/cli/src/test/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ArDoCoCLITest.java
+++ b/cli/src/test/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ArDoCoCLITest.java
@@ -12,7 +12,7 @@ class ArDoCoCLITest {
     private static final String OUTPUT = "src/test/resources/testout";
     private static final String TEXT = "../tests/src/test/resources/benchmark/teastore/teastore.txt";
     private static final String MODEL = "../tests/src/test/resources/benchmark/teastore/original_model/teastore.repository";
-    private static final String NAME = "test_teastore";
+    private static final String NAME = "teastore";
 
     @BeforeAll
     public static void beforeAll() {
@@ -30,7 +30,7 @@ class ArDoCoCLITest {
         var additionalConfigs = ArDoCo.loadAdditionalConfigs(runner.additionalConfigs());
         ArDoCo arDoCo = null;
         try {
-            arDoCo = ArDoCo.defineArDoCo(runner.inputText(), runner.inputModelArchitecture(), runner.inputModelCode(), additionalConfigs);
+            arDoCo = ArDoCo.defineArDoCo(runner.name(), runner.inputText(), runner.inputModelArchitecture(), runner.inputModelCode(), additionalConfigs);
         } catch (IOException e) {
             Assertions.fail("Could not define ArDoCo");
         }

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/ProjectPipelineData.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/data/ProjectPipelineData.java
@@ -1,0 +1,20 @@
+/* Licensed under MIT 2022. */
+package edu.kit.kastel.mcse.ardoco.core.api.data;
+
+import edu.kit.kastel.informalin.data.PipelineStepData;
+import edu.kit.kastel.informalin.framework.common.ICopyable;
+
+/**
+ * {@link ProjectPipelineData} represents data that we know overall about the project such as the name of the project.
+ */
+public interface ProjectPipelineData extends PipelineStepData, ICopyable<ProjectPipelineData> {
+    String ID = "ProjectPipelineData";
+
+    /**
+     * Return the project name
+     * 
+     * @return the project name
+     */
+    String getProjectName();
+
+}

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/output/ArDoCoResult.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/output/ArDoCoResult.java
@@ -38,6 +38,15 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.DataRepositoryHelper;
 public record ArDoCoResult(DataRepository dataRepository) {
 
     /**
+     * Returns the name of the project the results are based on.
+     * 
+     * @return the name of the project the results are based on.
+     */
+    public String getProjectName() {
+        return DataRepositoryHelper.getProjectPipelineData(dataRepository).getProjectName();
+    }
+
+    /**
      * Returns the set of {@link TraceLink}s that were found for the Model with the given ID.
      * 
      * @param modelId the ID of the model that should be traced

--- a/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/DataRepositoryHelper.java
+++ b/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/DataRepositoryHelper.java
@@ -3,6 +3,7 @@ package edu.kit.kastel.mcse.ardoco.core.common.util;
 
 import edu.kit.kastel.informalin.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.api.data.PreprocessingData;
+import edu.kit.kastel.mcse.ardoco.core.api.data.ProjectPipelineData;
 import edu.kit.kastel.mcse.ardoco.core.api.data.connectiongenerator.ConnectionStates;
 import edu.kit.kastel.mcse.ardoco.core.api.data.inconsistency.InconsistencyStates;
 import edu.kit.kastel.mcse.ardoco.core.api.data.model.ModelStates;
@@ -10,56 +11,166 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.recommendationgenerator.Recommen
 import edu.kit.kastel.mcse.ardoco.core.api.data.text.Text;
 import edu.kit.kastel.mcse.ardoco.core.api.data.textextraction.TextState;
 
+/**
+ * This class helps to access {@link DataRepository DataRepositories}. It provides methods to access the different
+ * {@link edu.kit.kastel.informalin.data.PipelineStepData} that is stored within the repository that are used within ArDoCo.
+ */
 public final class DataRepositoryHelper {
 
     private DataRepositoryHelper() {
         super();
     }
 
+    /**
+     * Checks whether there is {@link ProjectPipelineData} stored within the provided {@link DataRepository}
+     *
+     * @param dataRepository the DataRepository to access
+     * @return true, if there is {@link ProjectPipelineData} within the {@link DataRepository}; else, false
+     */
+    public static boolean hasProjectPipelineData(DataRepository dataRepository) {
+        return dataRepository.getData(ProjectPipelineData.ID, ProjectPipelineData.class).isPresent();
+    }
+
+    /**
+     * Returns the {@link ProjectPipelineData} stored within the provided {@link DataRepository}.
+     * This does not check if there actually is one and will fail and throw an {@link java.util.NoSuchElementException} if the data is not present.
+     * To make sure that there is data present, use {@link #hasProjectPipelineData(DataRepository)}
+     *
+     * @param dataRepository the DataRepository to access
+     * @return the data
+     */
+    public static ProjectPipelineData getProjectPipelineData(DataRepository dataRepository) {
+        return dataRepository.getData(ProjectPipelineData.ID, ProjectPipelineData.class).orElseThrow();
+    }
+
+    /**
+     * Checks whether there is annotated {@link Text} stored within the provided {@link DataRepository}
+     *
+     * @param dataRepository the DataRepository to access
+     * @return true, if there is {@link Text} within the {@link DataRepository}; else, false
+     */
     public static boolean hasAnnotatedText(DataRepository dataRepository) {
         return dataRepository.getData(PreprocessingData.ID, PreprocessingData.class).isPresent();
     }
 
+    /**
+     * Returns the {@link Text} stored within the provided {@link DataRepository}.
+     * This does not check if there actually is one and will fail and throw an {@link java.util.NoSuchElementException} if the data is not present.
+     * To make sure that there is data present, use {@link #hasAnnotatedText(DataRepository)}
+     *
+     * @param dataRepository the DataRepository to access
+     * @return the text
+     */
     public static Text getAnnotatedText(DataRepository dataRepository) {
         return dataRepository.getData(PreprocessingData.ID, PreprocessingData.class).orElseThrow().getText();
     }
 
+    /**
+     * Checks whether there is {@link TextState} stored within the provided {@link DataRepository}
+     *
+     * @param dataRepository the DataRepository to access
+     * @return true, if there is {@link TextState} within the {@link DataRepository}; else, false
+     */
     public static boolean hasTextState(DataRepository dataRepository) {
         return dataRepository.getData(TextState.ID, TextState.class).isPresent();
     }
 
+    /**
+     * Returns the {@link TextState} stored within the provided {@link DataRepository}.
+     * This does not check if there actually is one and will fail and throw an {@link java.util.NoSuchElementException} if the state is not present.
+     * To make sure that there is data present, use {@link #hasTextState(DataRepository)}
+     *
+     * @param dataRepository the DataRepository to access
+     * @return the state
+     */
     public static TextState getTextState(DataRepository dataRepository) {
         return dataRepository.getData(TextState.ID, TextState.class).orElseThrow();
     }
 
+    /**
+     * Checks whether there is {@link ModelStates} stored within the provided {@link DataRepository}
+     *
+     * @param dataRepository the DataRepository to access
+     * @return true, if there is {@link ModelStates} within the {@link DataRepository}; else, false
+     */
     public static boolean hasModelStatesData(DataRepository dataRepository) {
         return dataRepository.getData(ModelStates.ID, ModelStates.class).isPresent();
     }
 
+    /**
+     * Returns the {@link ModelStates} stored within the provided {@link DataRepository}.
+     * This does not check if there actually is one and will fail and throw an {@link java.util.NoSuchElementException} if the state is not present.
+     * To make sure that there is data present, use {@link #hasModelStatesData(DataRepository)}
+     *
+     * @param dataRepository the DataRepository to access
+     * @return the state
+     */
     public static ModelStates getModelStatesData(DataRepository dataRepository) {
         return dataRepository.getData(ModelStates.ID, ModelStates.class).orElseThrow();
     }
 
+    /**
+     * Checks whether there is {@link RecommendationStates} stored within the provided {@link DataRepository}
+     *
+     * @param dataRepository the DataRepository to access
+     * @return true, if there is {@link RecommendationStates} within the {@link DataRepository}; else, false
+     */
     public static boolean hasRecommendationStates(DataRepository dataRepository) {
         return dataRepository.getData(RecommendationStates.ID, RecommendationStates.class).isPresent();
     }
 
+    /**
+     * Returns the {@link RecommendationStates} stored within the provided {@link DataRepository}.
+     * This does not check if there actually is one and will fail and throw an {@link java.util.NoSuchElementException} if the state is not present.
+     * To make sure that there is data present, use {@link #hasRecommendationStates(DataRepository)}
+     *
+     * @param dataRepository the DataRepository to access
+     * @return the state
+     */
     public static RecommendationStates getRecommendationStates(DataRepository dataRepository) {
         return dataRepository.getData(RecommendationStates.ID, RecommendationStates.class).orElseThrow();
     }
 
+    /**
+     * Checks whether there is {@link ConnectionStates} stored within the provided {@link DataRepository}
+     *
+     * @param dataRepository the DataRepository to access
+     * @return true, if there is {@link ConnectionStates} within the {@link DataRepository}; else, false
+     */
     public static boolean hasConnectionStates(DataRepository dataRepository) {
         return dataRepository.getData(ConnectionStates.ID, ConnectionStates.class).isPresent();
     }
 
+    /**
+     * Returns the {@link ConnectionStates} stored within the provided {@link DataRepository}.
+     * This does not check if there actually is one and will fail and throw an {@link java.util.NoSuchElementException} if the state is not present.
+     * To make sure that there is data present, use {@link #hasConnectionStates(DataRepository)}
+     *
+     * @param dataRepository the DataRepository to access
+     * @return the state
+     */
     public static ConnectionStates getConnectionStates(DataRepository dataRepository) {
         return dataRepository.getData(ConnectionStates.ID, ConnectionStates.class).orElseThrow();
     }
 
+    /**
+     * Checks whether there is {@link InconsistencyStates} stored within the provided {@link DataRepository}
+     *
+     * @param dataRepository the DataRepository to access
+     * @return true, if there is {@link InconsistencyStates} within the {@link DataRepository}; else, false
+     */
     public static boolean hasInconsistencyStates(DataRepository dataRepository) {
         return dataRepository.getData(InconsistencyStates.ID, InconsistencyStates.class).isPresent();
     }
 
+    /**
+     * Returns the {@link InconsistencyStates} stored within the provided {@link DataRepository}.
+     * This does not check if there actually is one and will fail and throw an {@link java.util.NoSuchElementException} if the state is not present.
+     * To make sure that there is data present, use {@link #hasInconsistencyStates(DataRepository)}
+     *
+     * @param dataRepository the DataRepository to access
+     * @return the state
+     */
     public static InconsistencyStates getInconsistencyStates(DataRepository dataRepository) {
         return dataRepository.getData(InconsistencyStates.ID, InconsistencyStates.class).orElseThrow();
     }

--- a/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/ConnectionGenerator.java
+++ b/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/ConnectionGenerator.java
@@ -15,6 +15,7 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.connectiongenerator.ConnectionSt
 import edu.kit.kastel.mcse.ardoco.core.api.stage.AbstractExecutionStage;
 import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.agents.InitialConnectionAgent;
 import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.agents.InstanceConnectionAgent;
+import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.agents.ProjectNameFilterAgent;
 import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.agents.ReferenceAgent;
 
 /**
@@ -36,7 +37,8 @@ public class ConnectionGenerator extends AbstractExecutionStage {
     public ConnectionGenerator(DataRepository dataRepository) {
         super("ConnectionGenerator", dataRepository);
 
-        agents = Lists.mutable.of(new InitialConnectionAgent(dataRepository), new ReferenceAgent(dataRepository), new InstanceConnectionAgent(dataRepository));
+        agents = Lists.mutable.of(new InitialConnectionAgent(dataRepository), new ReferenceAgent(dataRepository), new ProjectNameFilterAgent(dataRepository),
+                new InstanceConnectionAgent(dataRepository));
         enabledAgents = agents.collect(Agent::getId);
     }
 

--- a/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/ProjectNameFilterAgent.java
+++ b/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/ProjectNameFilterAgent.java
@@ -1,0 +1,42 @@
+/* Licensed under MIT 2022. */
+package edu.kit.kastel.mcse.ardoco.core.connectiongenerator.agents;
+
+import java.util.List;
+import java.util.Map;
+
+import edu.kit.kastel.informalin.data.DataRepository;
+import edu.kit.kastel.informalin.framework.configuration.Configurable;
+import edu.kit.kastel.mcse.ardoco.core.api.agent.Informant;
+import edu.kit.kastel.mcse.ardoco.core.api.agent.PipelineAgent;
+import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.extractors.ProjectNameExtractor;
+
+public class ProjectNameFilterAgent extends PipelineAgent {
+    private final List<Informant> extractors;
+
+    @Configurable
+    private List<String> enabledExtractors;
+
+    /**
+     * Create the agent.
+     */
+    public ProjectNameFilterAgent(DataRepository dataRepository) {
+        super("ProjectNameFilterAgent", dataRepository);
+
+        extractors = List.of(new ProjectNameExtractor(dataRepository));
+        enabledExtractors = extractors.stream().map(e -> e.getClass().getSimpleName()).toList();
+    }
+
+    @Override
+    public void run() {
+        for (var extractor : findByClassName(enabledExtractors, extractors)) {
+            this.addPipelineStep(extractor);
+        }
+
+        super.run();
+    }
+
+    @Override
+    protected void delegateApplyConfigurationToInternalObjects(Map<String, String> additionalConfiguration) {
+        extractors.forEach(e -> e.applyConfiguration(additionalConfiguration));
+    }
+}

--- a/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/ProjectNameFilterAgent.java
+++ b/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/ProjectNameFilterAgent.java
@@ -8,8 +8,13 @@ import edu.kit.kastel.informalin.data.DataRepository;
 import edu.kit.kastel.informalin.framework.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.api.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.api.agent.PipelineAgent;
-import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.extractors.ProjectNameExtractor;
+import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.extractors.ProjectNameFinder;
 
+/**
+ * This agent should look for {@link edu.kit.kastel.mcse.ardoco.core.api.data.recommendationgenerator.RecommendedInstance RecommendedInstances} that contain the
+ * project's name and "filters" them by adding a heavy negative probability, thus making the
+ * {@link edu.kit.kastel.mcse.ardoco.core.api.data.recommendationgenerator.RecommendedInstance} extremely improbable.
+ */
 public class ProjectNameFilterAgent extends PipelineAgent {
     private final List<Informant> extractors;
 
@@ -22,7 +27,7 @@ public class ProjectNameFilterAgent extends PipelineAgent {
     public ProjectNameFilterAgent(DataRepository dataRepository) {
         super("ProjectNameFilterAgent", dataRepository);
 
-        extractors = List.of(new ProjectNameExtractor(dataRepository));
+        extractors = List.of(new ProjectNameFinder(dataRepository));
         enabledExtractors = extractors.stream().map(e -> e.getClass().getSimpleName()).toList();
     }
 

--- a/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/extractors/ProjectNameExtractor.java
+++ b/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/extractors/ProjectNameExtractor.java
@@ -1,0 +1,140 @@
+/* Licensed under MIT 2022. */
+package edu.kit.kastel.mcse.ardoco.core.connectiongenerator.extractors;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+
+import edu.kit.kastel.informalin.data.DataRepository;
+import edu.kit.kastel.informalin.framework.configuration.Configurable;
+import edu.kit.kastel.mcse.ardoco.core.api.agent.Informant;
+import edu.kit.kastel.mcse.ardoco.core.api.data.model.Metamodel;
+import edu.kit.kastel.mcse.ardoco.core.api.data.recommendationgenerator.RecommendationState;
+import edu.kit.kastel.mcse.ardoco.core.api.data.recommendationgenerator.RecommendedInstance;
+import edu.kit.kastel.mcse.ardoco.core.api.data.text.Word;
+import edu.kit.kastel.mcse.ardoco.core.api.data.textextraction.NounMapping;
+import edu.kit.kastel.mcse.ardoco.core.common.util.DataRepositoryHelper;
+import edu.kit.kastel.mcse.ardoco.core.common.util.SimilarityUtils;
+
+public class ProjectNameExtractor extends Informant {
+
+    @Configurable
+    public static final double PENALTY = Double.NEGATIVE_INFINITY;
+
+    public ProjectNameExtractor(DataRepository dataRepository) {
+        super("ProjectNameExtractor", dataRepository);
+    }
+
+    @Override
+    public void run() {
+        DataRepository dataRepository = getDataRepository();
+        var projectName = DataRepositoryHelper.getProjectPipelineData(dataRepository).getProjectName();
+        var modelStates = DataRepositoryHelper.getModelStatesData(dataRepository);
+        var recommendationStates = DataRepositoryHelper.getRecommendationStates(dataRepository);
+        for (var model : modelStates.modelIds()) {
+            var modelState = modelStates.getModelState(model);
+            Metamodel metamodel = modelState.getMetamodel();
+            var recommendationState = recommendationStates.getRecommendationState(metamodel);
+
+            checkForProjectNameInRecommendedInstances(projectName, recommendationState);
+        }
+    }
+
+    private void checkForProjectNameInRecommendedInstances(String projectName, RecommendationState recommendationState) {
+        for (var recommendedInstance : recommendationState.getRecommendedInstances()) {
+            checkForProjectNameInNounMappingsOfRecommendedInstance(projectName, recommendedInstance);
+        }
+    }
+
+    private void checkForProjectNameInNounMappingsOfRecommendedInstance(String projectName, RecommendedInstance recommendedInstance) {
+        for (var nm : recommendedInstance.getNameMappings()) {
+            checkWordsInNounMapping(projectName, recommendedInstance, nm);
+        }
+    }
+
+    private void checkWordsInNounMapping(String projectName, RecommendedInstance recommendedInstance, NounMapping nm) {
+        for (var word : nm.getWords()) {
+            String wordText = word.getText().toLowerCase();
+            if (projectName.contains(wordText)) {
+                var words = expandWordForName(projectName, word);
+                var expandedWord = concatenateWords(words);
+                if (SimilarityUtils.areWordsSimilar(projectName, expandedWord)) {
+                    recommendedInstance.addProbability(this, PENALTY);
+                }
+            }
+        }
+    }
+
+    private String concatenateWords(MutableList<Word> words) {
+        var sortedWords = words.sortThisByInt(Word::getPosition);
+        String concatenatedWords = "";
+        for (var word : sortedWords) {
+            concatenatedWords += word.getText().toLowerCase();
+        }
+        return concatenatedWords;
+    }
+
+    private MutableList<Word> expandWordForName(String projectName, Word word) {
+        MutableList<Word> words = Lists.mutable.with(word);
+        var editedProjectName = getEditedProjectName(projectName);
+
+        expandWordForNameLeft(editedProjectName, words);
+        expandWordForNameRight(editedProjectName, words);
+
+        return words.distinct().sortThisByInt(Word::getPosition);
+    }
+
+    private void expandWordForNameLeft(String name, MutableList<Word> words) {
+        Objects.requireNonNull(name);
+        if (words.isEmpty()) {
+            throw new IllegalArgumentException("List cannot be empty");
+        }
+
+        Word currWord = words.sortThisByInt(Word::getPosition).getFirstOptional().orElseThrow(IllegalArgumentException::new);
+        expandWordForName(name, currWord, words, (w) -> w.getPreWord(), (text, addition) -> addition + text);
+    }
+
+    private void expandWordForNameRight(String name, MutableList<Word> words) {
+        Objects.requireNonNull(name);
+        if (words.isEmpty()) {
+            throw new IllegalArgumentException("List cannot be empty");
+        }
+
+        var currWord = words.sortThisByInt(Word::getPosition).getLastOptional().orElseThrow(IllegalArgumentException::new);
+        expandWordForName(name, currWord, words, (w) -> w.getNextWord(), (text, addition) -> text + addition);
+    }
+
+    private void expandWordForName(String name, Word currWord, MutableList<Word> words, Function<Word, Word> wordExpansion,
+            BiFunction<String, String, String> concatenation) {
+        Objects.requireNonNull(name);
+        if (words.isEmpty()) {
+            throw new IllegalArgumentException("List cannot be empty");
+        }
+
+        var testWordText = concatenateWords(words);
+        while (name.contains(testWordText)) {
+            words.add(currWord);
+
+            currWord = wordExpansion.apply(currWord);
+            var wordText = "NON-MATCHING";
+            if (currWord != null) {
+                wordText = currWord.getText().toLowerCase();
+            }
+            testWordText = concatenation.apply(testWordText, wordText);
+        }
+    }
+
+    private static String getEditedProjectName(String projectName) {
+        // remove white spaces from project name
+        return projectName.replaceAll("\s", "");
+    }
+
+    @Override
+    protected void delegateApplyConfigurationToInternalObjects(Map<String, String> map) {
+        // handle additional configuration
+    }
+}

--- a/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/extractors/ProjectNameFinder.java
+++ b/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/extractors/ProjectNameFinder.java
@@ -20,12 +20,21 @@ import edu.kit.kastel.mcse.ardoco.core.api.data.textextraction.NounMapping;
 import edu.kit.kastel.mcse.ardoco.core.common.util.DataRepositoryHelper;
 import edu.kit.kastel.mcse.ardoco.core.common.util.SimilarityUtils;
 
-public class ProjectNameExtractor extends Informant {
+/**
+ * This informant looks for (parts of) the project's name within RecommendedInstances and if it finds the project's name, influences the probability of the
+ * RecommendedInstance negatively because it then should not be a recommended instance.
+ */
+public class ProjectNameFinder extends Informant {
 
     @Configurable
     public static final double PENALTY = Double.NEGATIVE_INFINITY;
 
-    public ProjectNameExtractor(DataRepository dataRepository) {
+    /**
+     * Constructs a new instance of the {@link ProjectNameFinder} with the given data repository.
+     * 
+     * @param dataRepository the data repository
+     */
+    public ProjectNameFinder(DataRepository dataRepository) {
         super("ProjectNameExtractor", dataRepository);
     }
 

--- a/pipeline/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ProjectPipelineDataImpl.java
+++ b/pipeline/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/ProjectPipelineDataImpl.java
@@ -1,0 +1,32 @@
+/* Licensed under MIT 2022. */
+package edu.kit.kastel.mcse.ardoco.core.pipeline;
+
+import edu.kit.kastel.mcse.ardoco.core.api.data.ProjectPipelineData;
+
+/**
+ * Implementation of {@link ProjectPipelineData} that simply takes the project's name in the constructor to store it.
+ */
+public class ProjectPipelineDataImpl implements ProjectPipelineData {
+
+    private final String projectName;
+
+    /**
+     * Construct this class using the project's name
+     * 
+     * @param projectName the project's name
+     */
+    ProjectPipelineDataImpl(String projectName) {
+        super();
+        this.projectName = projectName;
+    }
+
+    @Override
+    public String getProjectName() {
+        return projectName;
+    }
+
+    @Override
+    public ProjectPipelineData createCopy() {
+        return new ProjectPipelineDataImpl(projectName);
+    }
+}

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/TestUtil.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/TestUtil.java
@@ -161,6 +161,14 @@ public class TestUtil {
         logger.info(infoString);
     }
 
+    /**
+     * Creates a string from the given results that can be used, e.g., for logging. Extracts the name as well as precision, recall and F1-score and displays
+     * them line by line.
+     * 
+     * @param name    the name that should be displayed
+     * @param results the results
+     * @return a String containing the name and the results (precision, recall, F1) line by line
+     */
     public static String createResultLogString(String name, EvaluationResults results) {
         return String.format(Locale.ENGLISH, "%n%s:%n\tPrecision:%7.3f%n\tRecall:%10.3f%n\tF1:%14.3f", name, results.getPrecision(), results.getRecall(),
                 results.getF1());

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/Project.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/Project.java
@@ -16,7 +16,7 @@ public enum Project {
             "src/test/resources/benchmark/mediastore/mediastore.txt", //
             "src/test/resources/benchmark/mediastore/goldstandard.csv", //
             new EvaluationResults(.999, .620, .765), //
-            new EvaluationResults(.000, .000, .246) //
+            new EvaluationResults(.000, .000, .256) //
     ), //
     TEAMMATES( //
             "src/test/resources/benchmark/teammates/original_model/teammates.repository", //

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/InconsistencyDetectionEvaluationIT.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/InconsistencyDetectionEvaluationIT.java
@@ -126,7 +126,7 @@ class InconsistencyDetectionEvaluationIT {
      */
     @DisplayName("Evaluate Inconsistency Analyses")
     @ParameterizedTest(name = "Evaluating {0}")
-    @EnumSource(Project.class)
+    @EnumSource(value = Project.class)
     void inconsistencyIT(Project project) {
         logger.info("Start evaluation of inconsistency for {}", project.name());
         HoldBackRunResultsProducer holdBackRunResultsProducer = new HoldBackRunResultsProducer();
@@ -152,7 +152,7 @@ class InconsistencyDetectionEvaluationIT {
     @EnabledIfEnvironmentVariable(named = "testBaseline", matches = ".*")
     @DisplayName("Evaluate Inconsistency Analyses Baseline")
     @ParameterizedTest(name = "Evaluating Baseline For {0}")
-    @EnumSource(Project.class)
+    @EnumSource(value = Project.class)
     void inconsistencyBaselineIT(Project project) {
         logger.info("Start evaluation of inconsistency baseline for {}", project.name());
         ranBaseline = true;

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/InconsistencyDetectionEvaluationIT.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/InconsistencyDetectionEvaluationIT.java
@@ -67,12 +67,10 @@ class InconsistencyDetectionEvaluationIT {
 
         if (logger.isInfoEnabled()) {
             var name = "Overall Weighted";
-            var resultString = TestUtil.createResultLogString(name, weightedResults);
-            logger.info(resultString);
+            TestUtil.logResults(logger, name, weightedResults);
 
             name = "Overall Macro";
-            resultString = TestUtil.createResultLogString(name, macroResults);
-            logger.info(resultString);
+            TestUtil.logResults(logger, name, weightedResults);
 
             if (ranBaseline) {
                 name = "BASELINE Overall Weighted";

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceabilityLinkRecoveryEvaluationIT.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceabilityLinkRecoveryEvaluationIT.java
@@ -129,7 +129,7 @@ class TraceabilityLinkRecoveryEvaluationIT {
         inputText = project.getTextFile();
 
         // execute pipeline
-        ArDoCoResult arDoCoResult = ArDoCo.runAndSave("test_" + name, inputText, inputModel, null, additionalConfigs, outputDir);
+        ArDoCoResult arDoCoResult = ArDoCo.runAndSave(name, inputText, inputModel, null, additionalConfigs, outputDir);
         Assertions.assertNotNull(arDoCoResult);
 
         // calculate results and compare to expected results

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceabilityLinkRecoveryEvaluationIT.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceabilityLinkRecoveryEvaluationIT.java
@@ -124,21 +124,21 @@ class TraceabilityLinkRecoveryEvaluationIT {
     @ParameterizedTest(name = "Evaluating {0} (Text)")
     @EnumSource(value = Project.class)
     void evaluateTraceLinkRecoveryIT(Project project) {
-        var name = project.name().toLowerCase();
         inputModel = project.getModelFile();
         inputText = project.getTextFile();
 
         // execute pipeline
-        ArDoCoResult arDoCoResult = ArDoCo.runAndSave(name, inputText, inputModel, null, additionalConfigs, outputDir);
+        ArDoCoResult arDoCoResult = ArDoCo.runAndSave(project.name().toLowerCase(), inputText, inputModel, null, additionalConfigs, outputDir);
         Assertions.assertNotNull(arDoCoResult);
 
         // calculate results and compare to expected results
-        checkResults(project, name, arDoCoResult);
+        checkResults(project, arDoCoResult);
 
         writeDetailedOutput(project, arDoCoResult);
     }
 
-    private void checkResults(Project project, String name, ArDoCoResult arDoCoResult) {
+    private void checkResults(Project project, ArDoCoResult arDoCoResult) {
+        String name = project.name().toLowerCase();
         var modelIds = arDoCoResult.getModelIds();
         var modelId = modelIds.stream().findFirst().orElseThrow();
         var model = arDoCoResult.getModelState(modelId);

--- a/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/inconsistencyhelper/HoldBackRunResultsProducer.java
+++ b/tests/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/inconsistencyhelper/HoldBackRunResultsProducer.java
@@ -42,6 +42,7 @@ public class HoldBackRunResultsProducer {
     public Map<ModelInstance, ArDoCoResult> produceHoldBackRunResults(Project project, boolean useBaselineApproach) {
         Map<ModelInstance, ArDoCoResult> runs = new HashMap<ModelInstance, ArDoCoResult>();
 
+        var projectName = project.name().toLowerCase();
         inputModel = project.getModelFile();
         inputText = project.getTextFile();
 
@@ -49,7 +50,7 @@ public class HoldBackRunResultsProducer {
 
         ArDoCo arDoCoBaseRun;
         try {
-            arDoCoBaseRun = definePipelineBase(inputText, holdElementsBackModelConnector, useBaselineApproach);
+            arDoCoBaseRun = definePipelineBase(projectName, inputText, holdElementsBackModelConnector, useBaselineApproach);
         } catch (IOException e) {
             Assertions.fail(e);
             return runs;
@@ -77,9 +78,9 @@ public class HoldBackRunResultsProducer {
         return new HoldElementsBackModelConnector(pcmModel);
     }
 
-    private static ArDoCo definePipelineBase(File inputText, HoldElementsBackModelConnector holdElementsBackModelConnector, boolean useInconsistencyBaseline)
-            throws FileNotFoundException {
-        ArDoCo arDoCo = new ArDoCo();
+    private static ArDoCo definePipelineBase(String projectName, File inputText, HoldElementsBackModelConnector holdElementsBackModelConnector,
+            boolean useInconsistencyBaseline) throws FileNotFoundException {
+        ArDoCo arDoCo = new ArDoCo(projectName);
         var dataRepository = arDoCo.getDataRepository();
         var additionalConfigs = ArDoCo.loadAdditionalConfigs(null);
 
@@ -98,7 +99,8 @@ public class HoldBackRunResultsProducer {
 
     private static ArDoCo defineArDoCoWithPreComputedData(ArDoCoResult precomputedResults, HoldElementsBackModelConnector holdElementsBackModelConnector,
             boolean useInconsistencyBaseline) {
-        ArDoCo arDoCo = new ArDoCo();
+        var projectName = precomputedResults.getProjectName();
+        ArDoCo arDoCo = new ArDoCo(projectName);
         var dataRepository = arDoCo.getDataRepository();
         var additionalConfigs = ArDoCo.loadAdditionalConfigs(null);
 


### PR DESCRIPTION
With this PR, the project name will be considered when processing the text. This means that the project name will be stored within the data repository and can be used by agent. A new `ProjectNameFilterAgent `along with its informant `ProjectNameExtractor` will detect the RecommendedInstances that actually are the project's name and add a massive negative weight so they will not be regarded when trying to detect inconsistencies (missing elements). As a result, the evaluation results for InconsistencyDetection slightly improve (due to increased precision)