### PR TITLE
Feature/Update GitHub actions w.r.t. Java version and caching

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -20,10 +20,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-java@v3
+      - uses: joshlong/java-version-export-github-action@v17
+        id: jve
+      - name: Set up JDK
+        uses: actions/setup-java@v3
         with:
-          java-version: 17
           distribution: 'temurin'
+          java-version: ${{ steps.jve.outputs.java_major_version }}
+          cache: 'maven'
 
       - name: Set maven settings.xml
         uses: whelk-io/maven-settings-xml-action@v20

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,10 +14,14 @@ jobs:
       - uses: actions/checkout@v3
       - name: Fix Deployment for GH Pages
         run: mkdir -p docs/_build/dirhtml/ && touch docs/_build/dirhtml/.nojekyll
-      - uses: actions/setup-java@v3
+      - uses: joshlong/java-version-export-github-action@v17
+        id: jve
+      - name: Set up JDK
+        uses: actions/setup-java@v3
         with:
-          java-version: 17
           distribution: 'temurin'
+          java-version: ${{ steps.jve.outputs.java_major_version }}
+          cache: 'maven'
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,7 +2,7 @@ name: Format
 
 on:
   pull_request:
-    branches: [main]
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -12,25 +12,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-        fetch-depth: 0
-    - name: Set up JDK
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: 17
-
-    - name: Cache Maven packages
-      uses: actions/cache@v3
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-    - name: Format with Spotless in Maven
-      run: mvn -B spotless:apply --file pom.xml
-    - name: Commit changes
-      uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        commit_message: Apply formatting changes
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
+      - uses: joshlong/java-version-export-github-action@v17
+        id: jve
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ steps.jve.outputs.java_major_version }}
+          cache: 'maven'
+      - name: Format with Spotless in Maven
+        run: mvn -B spotless:apply --file pom.xml
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Apply formatting changes

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [ main, cleanup, refactoring, restructuring ]
   pull_request:
-    types: [opened, synchronize, reopened]
-    
+    types: [ opened, synchronize, reopened ]
+
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -20,11 +20,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - uses: joshlong/java-version-export-github-action@v17
+        id: jve
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: ${{ steps.jve.outputs.java_major_version }}
+          cache: 'maven'
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
@@ -32,12 +35,7 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -30,16 +30,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - uses: joshlong/java-version-export-github-action@v17
+        id: jve
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          java-version: ${{ steps.jve.outputs.java_major_version }}
+          cache: 'maven'
       - name: Verify with Maven
         run: mvn -B verify --file pom.xml -U -Dparallel=all -DperCoreThreadCount=false -DthreadCount=8 -T 1C


### PR DESCRIPTION
This PR updates how the Java version for setting up Java is done. Instead of having the chance to accidentally set different versions in maven and the action, the version is pulled out of the maven project and set for the action (via setup-java). This is done using [joshlong/java-version-export-github-action](https://github.com/joshlong/java-version-export-github-action) (see also [this tweet by Josh Long](https://twitter.com/starbuxman/status/1566702980543692800)).

Additionally, removed the caching action in favor of using the caching mechanism of the setup-java action. 