### PR TITLE
Deprecate Documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,21 +23,7 @@ project = 'ArDoCo - The Consistency Analyzer'
 copyright = f"2020-{datetime.now().year}, Sophie Corallo, Jan Keim, Dominik Fuchß"
 author = 'Sophie Corallo, Jan Keim, Dominik Fuchß'
 
-
-# The full version, including alpha/beta/rc tags
-def _find_release():
-    with open(os.path.join(os.path.dirname(__file__), "..", ".mvn", "maven.config"), "r") as file:
-        for line in file.readlines():
-            line = line.strip()
-            if line.startswith("-Drevision="):
-                version = line[len("-Drevision="):].strip()
-                if "-SNAPSHOT" in version:
-                    version = version[0:version.index("-")] + " (dev)"
-                return version
-    return "unknown"
-
-
-release = _find_release()
+release = "0.8.0"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/content/data/connectionData.rst
+++ b/docs/content/data/connectionData.rst
@@ -1,7 +1,7 @@
 Connection Data
 =================
 
-.. warning:: This site is deprecated
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
 
 
 Connection State

--- a/docs/content/data/inconsistencyData.rst
+++ b/docs/content/data/inconsistencyData.rst
@@ -1,7 +1,7 @@
 Inconsistency Data
 ===================
 
-.. note:: This documentation is currently built up
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
 
 Inconsistencies
 -------------------

--- a/docs/content/data/modelData.rst
+++ b/docs/content/data/modelData.rst
@@ -2,7 +2,7 @@
 Model
 ==========
 
-.. warning:: This site is deprecated and currently built up
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
 
 
 Model Extraction State

--- a/docs/content/data/recommendationData.rst
+++ b/docs/content/data/recommendationData.rst
@@ -1,7 +1,7 @@
 Recommendation Data
 ====================
 
-.. warning:: This site is deprecated
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
 
 Recommendation State
 -------------------------

--- a/docs/content/data/textData.rst
+++ b/docs/content/data/textData.rst
@@ -1,7 +1,7 @@
 Text Data
 ================
 
-.. note:: This documentation is currently built up
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
 
 
 Word

--- a/docs/content/data/textextractionData.rst
+++ b/docs/content/data/textextractionData.rst
@@ -2,7 +2,7 @@
 Extracted Text Data
 ====================
 
-.. warning:: This site is deprecated
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
 
 Text Extraction State
 ------------------------

--- a/docs/content/datastructures.rst
+++ b/docs/content/datastructures.rst
@@ -12,4 +12,4 @@ Data Structures
    data/inconsistencyData
 
 
-.. note:: This documentation is currently built up
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_

--- a/docs/content/pipeline.rst
+++ b/docs/content/pipeline.rst
@@ -1,6 +1,8 @@
 Pipeline
 ===============
 
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
+
 ArDoCo recognizes inconsistencies between a model and a documentation.
 Therefore, it is divided into multiple steps that can be seen as pipeline:
 

--- a/docs/content/quickstart.rst
+++ b/docs/content/quickstart.rst
@@ -1,6 +1,8 @@
 Quickstart
 =============
 
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
+
 The ArDoCo-Core is a maven project and can be embedded by using its specs (from the `pom <https://github.com/ArDoCo/Core/blob/main/pom.xml>`_).
 
 You can run and configure the execution with the :doc:`CLI <quickstart/cli>`.

--- a/docs/content/quickstart/cli.rst
+++ b/docs/content/quickstart/cli.rst
@@ -1,6 +1,8 @@
 Command Line Interface
 ===========================
 
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
+
 `ArDoCo Core <https://github.com/ArDoCo/Core>`_ contains a CLI that supports the execution of ArDoCo.
 
 It is necessary to specify an input model as well as a textual documentation.

--- a/docs/content/quickstart/saveActions.rst
+++ b/docs/content/quickstart/saveActions.rst
@@ -2,6 +2,8 @@
 Save Actions
 ==================
 
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
+
 Go to your Eclipse Workspace folder and open the file ``.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.ui.prefs``.
 
 There, exchange all the ``sp_cleanup.`` properties to the following:

--- a/docs/content/quickstart/standardConfiguration.rst
+++ b/docs/content/quickstart/standardConfiguration.rst
@@ -1,6 +1,8 @@
 Standard Configuration
 =========================
 
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
+
 .. code-block::
 
     ArticleTypeNameExtractor::enabled=false

--- a/docs/content/stages.rst
+++ b/docs/content/stages.rst
@@ -2,7 +2,7 @@
 Stages
 ======
 
-.. warning:: This site is deprecated
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
 
 As described in the [Overview](https://github.com/ArDoCo/Core/wiki/Overview), every stage of the approach is represented by a different component.
 In this section of the wiki, the common principles of these parts are described.

--- a/docs/content/stages/connectionGeneration.rst
+++ b/docs/content/stages/connectionGeneration.rst
@@ -1,7 +1,7 @@
 Connection Generation
 ===========================
 
-.. warning:: This site is deprecated
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
 
 As described in the `Overview <https://github.com/ArDoCo/Core/wiki/Overview>`_, the `Connection Agent <https://github.com/ArDoCo/Core/blob/main/src/main/java/modelconnector/connectionGenerator/ConnectionAgent.java>`_ creates connections between elements (extracted from the model) and textually identified elements.
 The goal in this stage is to identify similar elements on both sides.

--- a/docs/content/stages/inconsistencyGeneration.rst
+++ b/docs/content/stages/inconsistencyGeneration.rst
@@ -1,5 +1,5 @@
 Inconstistency Generation
 ===========================
 
-.. note:: This documentation is currently built up
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
 

--- a/docs/content/stages/modelExtraction.rst
+++ b/docs/content/stages/modelExtraction.rst
@@ -1,7 +1,7 @@
 Model Extractor
 ================
 
-.. warning:: This site is deprecated
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
 
 Since the `Model Extractor <https://github.com/ArDoCo/Core/blob/main/src/main/java/modelconnector/modelExtractor/ModelExtractor.java>`_ is currently under development, the input models have to be hardcoded.
 For more information on this topic see `Setup <https://github.com/ArDoCo/Core/wiki/Setup>`_.

--- a/docs/content/stages/recommendationGeneration.rst
+++ b/docs/content/stages/recommendationGeneration.rst
@@ -2,7 +2,7 @@ Recommendation Generation
 ===========================
 
 
-.. warning:: This site is deprecated
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
 
 
 As described in the `Overview <https://github.com/ArDoCo/Core/wiki/Overview>`_, the `Recommendation Agent <https://github.com/ArDoCo/Core/blob/main/src/main/java/modelconnector/recommendationGenerator/RecommendationAgent.java>`_ creates recommendations for model elements based on the textual knowledge.

--- a/docs/content/stages/textExtraction.rst
+++ b/docs/content/stages/textExtraction.rst
@@ -2,7 +2,7 @@ Text Extractor
 =================
 
 
-.. warning:: This site is deprecated
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
 
 
 Preprocessing

--- a/docs/content/stages/textPreprocessing.rst
+++ b/docs/content/stages/textPreprocessing.rst
@@ -1,3 +1,4 @@
 Text Preprocessing
 ======================
 
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_

--- a/docs/content/wordsimilarity.rst
+++ b/docs/content/wordsimilarity.rst
@@ -2,6 +2,8 @@
 Word similarity metrics
 =======================
 
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
+
 In ArDoCo, we use Word Similarity Metrics to assess how similar words (or strings) are.
 To use these metrics, simply call the appropriate methods in the `SimilarityUtils class <https://github.com/ArDoCo/Core/blob/main/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/SimilarityUtils.java>`_.
 The package `edu.kit.kastel.mcse.ardoco.core.common.util.wordsim <https://github.com/ArDoCo/Core/blob/main/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/wordsim>`_ provides different means to tailor the comparisons, most notably via the `WordSimUtils class <https://github.com/ArDoCo/Core/blob/main/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/wordsim/WordSimUtils.java>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,8 @@
 ArDoCo
 ===========
 
+.. error:: This site is deprecated. Please use our new `Wiki <https://github.com/ArDoCo/Core/wiki>`_
+
 ArDoCo (Architecture Documentation Consistency) is a framework to connect architecture documentation and models while identifying missing or deviating elements (inconsistencies).
 An element can be any representable item of the model, like a component or a relation.
 To do so, ArDoCo first creates trace links and then makes use of them and other information to identify inconsistencies.


### PR DESCRIPTION
This PR adds a deprecation information to the Documentation built using sphinx.
The new documentation will be deployed to https://github.com/ArDoCo/Core/wiki using simple markdown files (next PR to open)