### PR TITLE
Configurable redesign

### DIFF
--- a/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/configuration/AbstractConfigurable.java
+++ b/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/configuration/AbstractConfigurable.java
@@ -25,18 +25,6 @@ public abstract class AbstractConfigurable implements IConfigurable {
 
     private SortedMap<String, String> lastAppliedConfiguration = new TreeMap<>();
 
-    protected final <E> List<E> findByClassName(List<String> selected, List<E> instances) {
-        List<E> target = new ArrayList<>(0);
-        for (var clazz : selected) {
-            var elem = instances.stream()
-                    .filter(e -> e.getClass().getSimpleName().equals(clazz))
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("Could not find " + clazz));
-            target.add(elem);
-        }
-        return target;
-    }
-
     @Override
     public final void applyConfiguration(SortedMap<String, String> additionalConfiguration) {
         applyConfiguration(additionalConfiguration, this.getClass());

--- a/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/configuration/AbstractConfigurable.java
+++ b/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/configuration/AbstractConfigurable.java
@@ -62,17 +62,26 @@ public abstract class AbstractConfigurable implements IConfigurable {
         applyConfiguration(additionalConfiguration, configurable, currentClassInHierarchy.getSuperclass());
     }
 
+    /**
+     * Returns the key (for the configuration file) of a field. If the field is marked as ChildClassConfigurable, the key is based on the class of the
+     * configurable object. Otherwise, the key is based on the class where the field is defined.
+     * 
+     * @param configurable            the configurable object
+     * @param currentClassInHierarchy the class where the field is defined
+     * @param field                   the field
+     * @return the key of the field
+     */
     public static String getKeyOfField(AbstractConfigurable configurable, Class<?> currentClassInHierarchy, Field field) {
-        Configurable c = field.getAnnotation(Configurable.class);
-        ChildClassConfigurable ccc = field.getAnnotation(ChildClassConfigurable.class);
+        Configurable configurableAnnotation = field.getAnnotation(Configurable.class);
+        ChildClassConfigurable childClassConfigurableAnnotation = field.getAnnotation(ChildClassConfigurable.class);
 
-        if (ccc != null && !c.key().isBlank()) {
+        if (childClassConfigurableAnnotation != null && !configurableAnnotation.key().isBlank()) {
             throw new IllegalStateException("You cannot define a key for a field that is marked as ChildClassConfigurable.");
         }
 
-        String classOfDefinition = ccc == null ? currentClassInHierarchy.getSimpleName() : configurable.getClass().getSimpleName();
+        String classOfDefinition = childClassConfigurableAnnotation == null ? currentClassInHierarchy.getSimpleName() : configurable.getClass().getSimpleName();
 
-        return c.key().isBlank() ? (classOfDefinition + CLASS_ATTRIBUTE_CONNECTOR + field.getName()) : c.key();
+        return configurableAnnotation.key().isBlank() ? (classOfDefinition + CLASS_ATTRIBUTE_CONNECTOR + field.getName()) : configurableAnnotation.key();
     }
 
     private void setValue(Field field, String value) {

--- a/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/configuration/ChildClassConfigurable.java
+++ b/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/configuration/ChildClassConfigurable.java
@@ -1,0 +1,18 @@
+/* Licensed under MIT 2023. */
+package edu.kit.kastel.mcse.ardoco.core.configuration;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation marks a field that is configurable as configured by child class. That means that the key that is used to configure the field is based on the
+ * actual class (not on the class where the configurable field is defined).
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Target(ElementType.FIELD)
+public @interface ChildClassConfigurable {
+}

--- a/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/configuration/NoConfiguration.java
+++ b/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/configuration/NoConfiguration.java
@@ -1,0 +1,18 @@
+/* Licensed under MIT 2023. */
+package edu.kit.kastel.mcse.ardoco.core.configuration;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is used to mark classes that should not be configured. This means that the fields of the class will not be modified. The cascade
+ * configuration will be applied to the fields of the class.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Target(ElementType.TYPE)
+public @interface NoConfiguration {
+}

--- a/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/AbstractExecutionStage.java
+++ b/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/AbstractExecutionStage.java
@@ -2,7 +2,13 @@
 package edu.kit.kastel.mcse.ardoco.core.pipeline;
 
 import java.util.List;
+import java.util.SortedMap;
 
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+
+import edu.kit.kastel.mcse.ardoco.core.configuration.ChildClassConfigurable;
+import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
@@ -11,18 +17,26 @@ import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
  * Inconsistency-Checker.
  * <p>
  * Implementing classes need to implement {@link #initializeState()} that cares for setting up the state for processing.
- * Additionally, implementing classes need to implement {@link #getEnabledAgentIds()}} and {@link #getAllAgents()}.
  */
 public abstract class AbstractExecutionStage extends Pipeline {
 
+    private final MutableList<PipelineAgent> agents;
+
+    @Configurable
+    @ChildClassConfigurable
+    private List<String> enabledAgents;
+
     /**
      * Constructor for ExecutionStages
-     *
+     * 
+     * @param agents         the agents that could be executed by this pipeline
      * @param id             the id of the stage
      * @param dataRepository the {@link DataRepository} that should be used
      */
-    protected AbstractExecutionStage(String id, DataRepository dataRepository) {
+    protected AbstractExecutionStage(List<? extends PipelineAgent> agents, String id, DataRepository dataRepository) {
         super(id, dataRepository);
+        this.agents = Lists.mutable.withAll(agents);
+        this.enabledAgents = this.agents.collect(PipelineAgent::getId);
     }
 
     @Override
@@ -37,9 +51,8 @@ public abstract class AbstractExecutionStage extends Pipeline {
     protected final void initialize() {
         initializeState();
 
-        var enabledAgentsIds = getEnabledAgentIds();
-        for (var agent : getAllAgents()) {
-            if (enabledAgentsIds.contains(agent.getId())) {
+        for (var agent : agents) {
+            if (enabledAgents.contains(agent.getId())) {
                 this.addPipelineStep(agent);
             }
         }
@@ -50,17 +63,11 @@ public abstract class AbstractExecutionStage extends Pipeline {
      */
     protected abstract void initializeState();
 
-    /**
-     * Return the enabled {@link PipelineAgent agents}
-     *
-     * @return the list of agents ids
-     */
-    protected abstract List<String> getEnabledAgentIds();
-
-    /**
-     * Return the list of {@link PipelineAgent agents} that can be executed by this pipeline
-     *
-     * @return the list of agents
-     */
-    protected abstract List<PipelineAgent> getAllAgents();
+    @Override
+    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
+        super.delegateApplyConfigurationToInternalObjects(additionalConfiguration);
+        for (var agent : agents) {
+            agent.applyConfiguration(additionalConfiguration);
+        }
+    }
 }

--- a/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/AbstractExecutionStage.java
+++ b/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/AbstractExecutionStage.java
@@ -11,7 +11,7 @@ import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
  * Inconsistency-Checker.
  * <p>
  * Implementing classes need to implement {@link #initializeState()} that cares for setting up the state for processing.
- * Additionally, implementing classes need to implement {@link #getEnabledAgents()} that returns the listof enabled {@link PipelineAgent pipeline agents}
+ * Additionally, implementing classes need to implement {@link #getEnabledAgentIds()}} and {@link #getAllAgents()}.
  */
 public abstract class AbstractExecutionStage extends Pipeline {
 
@@ -37,8 +37,11 @@ public abstract class AbstractExecutionStage extends Pipeline {
     protected final void initialize() {
         initializeState();
 
-        for (var agent : getEnabledAgents()) {
-            this.addPipelineStep(agent);
+        var enabledAgentsIds = getEnabledAgentIds();
+        for (var agent : getAllAgents()) {
+            if (enabledAgentsIds.contains(agent.getId())) {
+                this.addPipelineStep(agent);
+            }
         }
     }
 
@@ -50,7 +53,14 @@ public abstract class AbstractExecutionStage extends Pipeline {
     /**
      * Return the enabled {@link PipelineAgent agents}
      *
+     * @return the list of agents ids
+     */
+    protected abstract List<String> getEnabledAgentIds();
+
+    /**
+     * Return the list of {@link PipelineAgent agents} that can be executed by this pipeline
+     *
      * @return the list of agents
      */
-    protected abstract List<PipelineAgent> getEnabledAgents();
+    protected abstract List<PipelineAgent> getAllAgents();
 }

--- a/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/agent/PipelineAgent.java
+++ b/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/agent/PipelineAgent.java
@@ -1,8 +1,12 @@
 /* Licensed under MIT 2022-2023. */
 package edu.kit.kastel.mcse.ardoco.core.pipeline.agent;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.SortedMap;
 
+import edu.kit.kastel.mcse.ardoco.core.configuration.ChildClassConfigurable;
+import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractExecutionStage;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.Pipeline;
@@ -11,13 +15,21 @@ import edu.kit.kastel.mcse.ardoco.core.pipeline.Pipeline;
  * This class represents a pipeline agent that calculates some results for an {@link AbstractExecutionStage} execution
  * stage}.
  *
- * Implementing classes need to override {@link #getAllPipelineSteps()} and {@link #getEnabledPipelineStepIds()}.
+ * Implementing classes need to override.
  * Additionally, sub-classes are free to override {@link #initializeState()} to execute code at the beginning of the initialization before the main processing.
  */
 public abstract class PipelineAgent extends Pipeline implements Agent {
 
-    protected PipelineAgent(String id, DataRepository dataRepository) {
+    private final List<Informant> informants;
+
+    @Configurable
+    @ChildClassConfigurable
+    private List<String> enabledInformants;
+
+    protected PipelineAgent(List<? extends Informant> informants, String id, DataRepository dataRepository) {
         super(id, dataRepository);
+        this.informants = new ArrayList<>(informants);
+        this.enabledInformants = informants.stream().map(Informant::getId).toList();
     }
 
     @Override
@@ -31,11 +43,8 @@ public abstract class PipelineAgent extends Pipeline implements Agent {
      */
     protected final void initialize() {
         initializeState();
-
-        var enabledPipelineStepIds = getEnabledPipelineStepIds();
-
-        for (var informant : getAllPipelineSteps()) {
-            if (enabledPipelineStepIds.contains(informant.getId())) {
+        for (var informant : informants) {
+            if (enabledInformants.contains(informant.getId())) {
                 this.addPipelineStep(informant);
             }
         }
@@ -48,17 +57,10 @@ public abstract class PipelineAgent extends Pipeline implements Agent {
         // do nothing here
     }
 
-    /**
-     * Return the enabled pipeline steps (informants)
-     *
-     * @return the list of informants ids
-     */
-    protected abstract List<String> getEnabledPipelineStepIds();
+    @Override
+    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
+        super.delegateApplyConfigurationToInternalObjects(additionalConfiguration);
+        informants.forEach(filter -> filter.applyConfiguration(additionalConfiguration));
+    }
 
-    /**
-     * Return all possible pipeline steps (informants)
-     *
-     * @return the list of Informants
-     */
-    protected abstract List<Informant> getAllPipelineSteps();
 }

--- a/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/agent/PipelineAgent.java
+++ b/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/pipeline/agent/PipelineAgent.java
@@ -11,7 +11,7 @@ import edu.kit.kastel.mcse.ardoco.core.pipeline.Pipeline;
  * This class represents a pipeline agent that calculates some results for an {@link AbstractExecutionStage} execution
  * stage}.
  *
- * Implementing classes need to override {@link #getEnabledPipelineSteps()}.
+ * Implementing classes need to override {@link #getAllPipelineSteps()} and {@link #getEnabledPipelineStepIds()}.
  * Additionally, sub-classes are free to override {@link #initializeState()} to execute code at the beginning of the initialization before the main processing.
  */
 public abstract class PipelineAgent extends Pipeline implements Agent {
@@ -31,8 +31,13 @@ public abstract class PipelineAgent extends Pipeline implements Agent {
      */
     protected final void initialize() {
         initializeState();
-        for (var informant : getEnabledPipelineSteps()) {
-            this.addPipelineStep(informant);
+
+        var enabledPipelineStepIds = getEnabledPipelineStepIds();
+
+        for (var informant : getAllPipelineSteps()) {
+            if (enabledPipelineStepIds.contains(informant.getId())) {
+                this.addPipelineStep(informant);
+            }
         }
     }
 
@@ -45,8 +50,15 @@ public abstract class PipelineAgent extends Pipeline implements Agent {
 
     /**
      * Return the enabled pipeline steps (informants)
-     * 
+     *
+     * @return the list of informants ids
+     */
+    protected abstract List<String> getEnabledPipelineStepIds();
+
+    /**
+     * Return all possible pipeline steps (informants)
+     *
      * @return the list of Informants
      */
-    protected abstract List<Informant> getEnabledPipelineSteps();
+    protected abstract List<Informant> getAllPipelineSteps();
 }

--- a/pipeline/pipeline-core/src/main/java/edu/kit/kastel/mcse/ardoco/core/execution/ConfigurationHelper.java
+++ b/pipeline/pipeline-core/src/main/java/edu/kit/kastel/mcse/ardoco/core/execution/ConfigurationHelper.java
@@ -100,7 +100,7 @@ public class ConfigurationHelper {
     private static void fillConfigs(AbstractConfigurable object, List<Field> fields, Map<String, String> configs) throws IllegalAccessException {
         for (Field f : fields) {
             f.setAccessible(true);
-            var key = f.getDeclaringClass().getSimpleName() + AbstractConfigurable.CLASS_ATTRIBUTE_CONNECTOR + f.getName();
+            var key = AbstractConfigurable.getKeyOfField(object, f.getDeclaringClass(), f);
             var rawValue = f.get(object);
             var value = getValue(rawValue);
             if (configs.containsKey(key)) {

--- a/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/SadCodeTraceabilityLinkRecovery.java
+++ b/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/SadCodeTraceabilityLinkRecovery.java
@@ -4,30 +4,16 @@ package edu.kit.kastel.mcse.ardoco.core.codetraceability;
 import java.util.List;
 import java.util.SortedMap;
 
-import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
-
 import edu.kit.kastel.mcse.ardoco.core.api.codetraceability.CodeTraceabilityState;
 import edu.kit.kastel.mcse.ardoco.core.codetraceability.agents.ArchitectureLinkToCodeLinkTransformerAgent;
 import edu.kit.kastel.mcse.ardoco.core.common.util.DataRepositoryHelper;
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractExecutionStage;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Agent;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 public class SadCodeTraceabilityLinkRecovery extends AbstractExecutionStage {
 
-    private final MutableList<PipelineAgent> agents;
-
-    @Configurable
-    private List<String> enabledAgents;
-
     public SadCodeTraceabilityLinkRecovery(DataRepository dataRepository) {
-        super(SadCodeTraceabilityLinkRecovery.class.getSimpleName(), dataRepository);
-
-        agents = Lists.mutable.of(new ArchitectureLinkToCodeLinkTransformerAgent(dataRepository));
-        enabledAgents = agents.collect(Agent::getId);
+        super(List.of(new ArchitectureLinkToCodeLinkTransformerAgent(dataRepository)), SadCodeTraceabilityLinkRecovery.class.getSimpleName(), dataRepository);
     }
 
     public static SadCodeTraceabilityLinkRecovery get(SortedMap<String, String> additionalConfigs, DataRepository dataRepository) {
@@ -42,24 +28,6 @@ public class SadCodeTraceabilityLinkRecovery extends AbstractExecutionStage {
         if (!DataRepositoryHelper.hasCodeTraceabilityState(dataRepository)) {
             var codeTraceabilityState = new CodeTraceabilityStateImpl();
             dataRepository.addData(CodeTraceabilityState.ID, codeTraceabilityState);
-        }
-    }
-
-    @Override
-    public List<String> getEnabledAgentIds() {
-        return enabledAgents;
-    }
-
-    @Override
-    protected List<PipelineAgent> getAllAgents() {
-        return this.agents;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        super.delegateApplyConfigurationToInternalObjects(additionalConfiguration);
-        for (var agent : agents) {
-            agent.applyConfiguration(additionalConfiguration);
         }
     }
 }

--- a/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/SadCodeTraceabilityLinkRecovery.java
+++ b/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/SadCodeTraceabilityLinkRecovery.java
@@ -46,8 +46,13 @@ public class SadCodeTraceabilityLinkRecovery extends AbstractExecutionStage {
     }
 
     @Override
-    protected List<PipelineAgent> getEnabledAgents() {
-        return findByClassName(enabledAgents, agents);
+    public List<String> getEnabledAgentIds() {
+        return enabledAgents;
+    }
+
+    @Override
+    protected List<PipelineAgent> getAllAgents() {
+        return this.agents;
     }
 
     @Override

--- a/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/SadSamCodeTraceabilityLinkRecovery.java
+++ b/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/SadSamCodeTraceabilityLinkRecovery.java
@@ -4,30 +4,17 @@ package edu.kit.kastel.mcse.ardoco.core.codetraceability;
 import java.util.List;
 import java.util.SortedMap;
 
-import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
-
 import edu.kit.kastel.mcse.ardoco.core.api.codetraceability.CodeTraceabilityState;
 import edu.kit.kastel.mcse.ardoco.core.codetraceability.agents.TransitiveTraceabilityAgent;
 import edu.kit.kastel.mcse.ardoco.core.common.util.DataRepositoryHelper;
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractExecutionStage;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Agent;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 public class SadSamCodeTraceabilityLinkRecovery extends AbstractExecutionStage {
 
-    private final MutableList<PipelineAgent> agents;
-
-    @Configurable
-    private List<String> enabledAgents;
-
     public SadSamCodeTraceabilityLinkRecovery(DataRepository dataRepository) {
-        super(SadSamCodeTraceabilityLinkRecovery.class.getSimpleName(), dataRepository);
+        super(List.of(new TransitiveTraceabilityAgent(dataRepository)), SadSamCodeTraceabilityLinkRecovery.class.getSimpleName(), dataRepository);
 
-        agents = Lists.mutable.of(new TransitiveTraceabilityAgent(dataRepository));
-        enabledAgents = agents.collect(Agent::getId);
     }
 
     public static SadSamCodeTraceabilityLinkRecovery get(SortedMap<String, String> additionalConfigs, DataRepository dataRepository) {
@@ -42,24 +29,6 @@ public class SadSamCodeTraceabilityLinkRecovery extends AbstractExecutionStage {
         if (!DataRepositoryHelper.hasCodeTraceabilityState(dataRepository)) {
             var codeTraceabilityState = new CodeTraceabilityStateImpl();
             dataRepository.addData(CodeTraceabilityState.ID, codeTraceabilityState);
-        }
-    }
-
-    @Override
-    public List<String> getEnabledAgentIds() {
-        return enabledAgents;
-    }
-
-    @Override
-    protected List<PipelineAgent> getAllAgents() {
-        return this.agents;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        super.delegateApplyConfigurationToInternalObjects(additionalConfiguration);
-        for (var agent : agents) {
-            agent.applyConfiguration(additionalConfiguration);
         }
     }
 }

--- a/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/SadSamCodeTraceabilityLinkRecovery.java
+++ b/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/SadSamCodeTraceabilityLinkRecovery.java
@@ -46,8 +46,13 @@ public class SadSamCodeTraceabilityLinkRecovery extends AbstractExecutionStage {
     }
 
     @Override
-    protected List<PipelineAgent> getEnabledAgents() {
-        return findByClassName(enabledAgents, agents);
+    public List<String> getEnabledAgentIds() {
+        return enabledAgents;
+    }
+
+    @Override
+    protected List<PipelineAgent> getAllAgents() {
+        return this.agents;
     }
 
     @Override

--- a/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/SamCodeTraceabilityLinkRecovery.java
+++ b/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/SamCodeTraceabilityLinkRecovery.java
@@ -4,30 +4,16 @@ package edu.kit.kastel.mcse.ardoco.core.codetraceability;
 import java.util.List;
 import java.util.SortedMap;
 
-import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
-
 import edu.kit.kastel.mcse.ardoco.core.api.codetraceability.CodeTraceabilityState;
 import edu.kit.kastel.mcse.ardoco.core.codetraceability.agents.InitialCodeTraceabilityAgent;
 import edu.kit.kastel.mcse.ardoco.core.common.util.DataRepositoryHelper;
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractExecutionStage;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Agent;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 public class SamCodeTraceabilityLinkRecovery extends AbstractExecutionStage {
 
-    private final MutableList<PipelineAgent> agents;
-
-    @Configurable
-    private List<String> enabledAgents;
-
     public SamCodeTraceabilityLinkRecovery(DataRepository dataRepository) {
-        super(SamCodeTraceabilityLinkRecovery.class.getSimpleName(), dataRepository);
-
-        agents = Lists.mutable.of(new InitialCodeTraceabilityAgent(dataRepository));
-        enabledAgents = agents.collect(Agent::getId);
+        super(List.of(new InitialCodeTraceabilityAgent(dataRepository)), SamCodeTraceabilityLinkRecovery.class.getSimpleName(), dataRepository);
     }
 
     public static SamCodeTraceabilityLinkRecovery get(SortedMap<String, String> additionalConfigs, DataRepository dataRepository) {
@@ -42,24 +28,6 @@ public class SamCodeTraceabilityLinkRecovery extends AbstractExecutionStage {
         if (!DataRepositoryHelper.hasCodeTraceabilityState(dataRepository)) {
             var codeTraceabilityState = new CodeTraceabilityStateImpl();
             dataRepository.addData(CodeTraceabilityState.ID, codeTraceabilityState);
-        }
-    }
-
-    @Override
-    public List<String> getEnabledAgentIds() {
-        return enabledAgents;
-    }
-
-    @Override
-    protected List<PipelineAgent> getAllAgents() {
-        return this.agents;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        super.delegateApplyConfigurationToInternalObjects(additionalConfiguration);
-        for (var agent : agents) {
-            agent.applyConfiguration(additionalConfiguration);
         }
     }
 }

--- a/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/SamCodeTraceabilityLinkRecovery.java
+++ b/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/SamCodeTraceabilityLinkRecovery.java
@@ -46,8 +46,13 @@ public class SamCodeTraceabilityLinkRecovery extends AbstractExecutionStage {
     }
 
     @Override
-    protected List<PipelineAgent> getEnabledAgents() {
-        return findByClassName(enabledAgents, agents);
+    public List<String> getEnabledAgentIds() {
+        return enabledAgents;
+    }
+
+    @Override
+    protected List<PipelineAgent> getAllAgents() {
+        return this.agents;
     }
 
     @Override

--- a/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/agents/ArchitectureLinkToCodeLinkTransformerAgent.java
+++ b/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/agents/ArchitectureLinkToCodeLinkTransformerAgent.java
@@ -35,8 +35,13 @@ public class ArchitectureLinkToCodeLinkTransformerAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledInformants, informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledInformants;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 
     @Override

--- a/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/agents/ArchitectureLinkToCodeLinkTransformerAgent.java
+++ b/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/agents/ArchitectureLinkToCodeLinkTransformerAgent.java
@@ -2,50 +2,23 @@
 package edu.kit.kastel.mcse.ardoco.core.codetraceability.agents;
 
 import java.util.List;
-import java.util.SortedMap;
-
-import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
 
 import edu.kit.kastel.mcse.ardoco.core.codetraceability.informants.ArchitectureLinkToCodeLinkTransformerInformant;
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 /**
  * This class transforms architecture trace links to code trace links by remapping the architecture ids (which are code ids) to the compilation units.
  */
 public class ArchitectureLinkToCodeLinkTransformerAgent extends PipelineAgent {
-    private final MutableList<Informant> informants;
-
-    @Configurable
-    private List<String> enabledInformants;
 
     public ArchitectureLinkToCodeLinkTransformerAgent(DataRepository dataRepository) {
-        super(ArchitectureLinkToCodeLinkTransformerAgent.class.getSimpleName(), dataRepository);
-
-        informants = Lists.mutable.of(new ArchitectureLinkToCodeLinkTransformerInformant(dataRepository));
-        enabledInformants = informants.collect(Informant::getId);
+        super(List.of(new ArchitectureLinkToCodeLinkTransformerInformant(dataRepository)), ArchitectureLinkToCodeLinkTransformerAgent.class.getSimpleName(),
+                dataRepository);
     }
 
     @Override
     protected void initializeState() {
         // empty
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledInformants;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(filter -> filter.applyConfiguration(additionalConfiguration));
     }
 }

--- a/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/agents/InitialCodeTraceabilityAgent.java
+++ b/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/agents/InitialCodeTraceabilityAgent.java
@@ -32,8 +32,13 @@ public class InitialCodeTraceabilityAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledInformants, informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledInformants;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 
     @Override

--- a/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/agents/InitialCodeTraceabilityAgent.java
+++ b/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/agents/InitialCodeTraceabilityAgent.java
@@ -2,47 +2,19 @@
 package edu.kit.kastel.mcse.ardoco.core.codetraceability.agents;
 
 import java.util.List;
-import java.util.SortedMap;
-
-import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
 
 import edu.kit.kastel.mcse.ardoco.core.codetraceability.informants.ArCoTLInformant;
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 public class InitialCodeTraceabilityAgent extends PipelineAgent {
-    private final MutableList<Informant> informants;
-
-    @Configurable
-    private List<String> enabledInformants;
 
     public InitialCodeTraceabilityAgent(DataRepository dataRepository) {
-        super(InitialCodeTraceabilityAgent.class.getSimpleName(), dataRepository);
-
-        informants = Lists.mutable.of(new ArCoTLInformant(dataRepository));
-        enabledInformants = informants.collect(Informant::getId);
+        super(List.of(new ArCoTLInformant(dataRepository)), InitialCodeTraceabilityAgent.class.getSimpleName(), dataRepository);
     }
 
     @Override
     protected void initializeState() {
         // empty
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledInformants;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(filter -> filter.applyConfiguration(additionalConfiguration));
     }
 }

--- a/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/agents/TransitiveTraceabilityAgent.java
+++ b/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/agents/TransitiveTraceabilityAgent.java
@@ -2,48 +2,19 @@
 package edu.kit.kastel.mcse.ardoco.core.codetraceability.agents;
 
 import java.util.List;
-import java.util.SortedMap;
-
-import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
 
 import edu.kit.kastel.mcse.ardoco.core.codetraceability.informants.TraceLinkCombiner;
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 public class TransitiveTraceabilityAgent extends PipelineAgent {
 
-    private final MutableList<Informant> informants;
-
-    @Configurable
-    private List<String> enabledInformants;
-
     public TransitiveTraceabilityAgent(DataRepository dataRepository) {
-        super(TransitiveTraceabilityAgent.class.getSimpleName(), dataRepository);
-
-        informants = Lists.mutable.of(new TraceLinkCombiner(dataRepository));
-        enabledInformants = informants.collect(Informant::getId);
+        super(List.of(new TraceLinkCombiner(dataRepository)), TransitiveTraceabilityAgent.class.getSimpleName(), dataRepository);
     }
 
     @Override
     protected void initializeState() {
         // empty
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledInformants;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(filter -> filter.applyConfiguration(additionalConfiguration));
     }
 }

--- a/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/agents/TransitiveTraceabilityAgent.java
+++ b/stages/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/core/codetraceability/agents/TransitiveTraceabilityAgent.java
@@ -33,8 +33,13 @@ public class TransitiveTraceabilityAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledInformants, informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledInformants;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 
     @Override

--- a/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/ConnectionGenerator.java
+++ b/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/ConnectionGenerator.java
@@ -4,19 +4,13 @@ package edu.kit.kastel.mcse.ardoco.core.connectiongenerator;
 import java.util.List;
 import java.util.SortedMap;
 
-import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
-
 import edu.kit.kastel.mcse.ardoco.core.api.connectiongenerator.ConnectionStates;
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.agents.InitialConnectionAgent;
 import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.agents.InstanceConnectionAgent;
 import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.agents.ProjectNameFilterAgent;
 import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.agents.ReferenceAgent;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractExecutionStage;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Agent;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 /**
  * The ModelConnectionAgent runs different analyzers and solvers. This agent creates recommendations as well as
@@ -25,22 +19,14 @@ import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
  */
 public class ConnectionGenerator extends AbstractExecutionStage {
 
-    private final MutableList<PipelineAgent> agents;
-
-    @Configurable
-    private List<String> enabledAgents;
-
     /**
      * Create the module.
      *
      * @param dataRepository the {@link DataRepository}
      */
     public ConnectionGenerator(DataRepository dataRepository) {
-        super("ConnectionGenerator", dataRepository);
-
-        agents = Lists.mutable.of(new InitialConnectionAgent(dataRepository), new ReferenceAgent(dataRepository), new ProjectNameFilterAgent(dataRepository),
-                new InstanceConnectionAgent(dataRepository));
-        enabledAgents = agents.collect(Agent::getId);
+        super(List.of(new InitialConnectionAgent(dataRepository), new ReferenceAgent(dataRepository), new ProjectNameFilterAgent(dataRepository),
+                new InstanceConnectionAgent(dataRepository)), "ConnectionGenerator", dataRepository);
     }
 
     /**
@@ -61,23 +47,4 @@ public class ConnectionGenerator extends AbstractExecutionStage {
         var connectionStates = ConnectionStatesImpl.build();
         getDataRepository().addData(ConnectionStates.ID, connectionStates);
     }
-
-    @Override
-    public List<String> getEnabledAgentIds() {
-        return enabledAgents;
-    }
-
-    @Override
-    protected List<PipelineAgent> getAllAgents() {
-        return this.agents;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        super.delegateApplyConfigurationToInternalObjects(additionalConfiguration);
-        for (var agent : agents) {
-            agent.applyConfiguration(additionalConfiguration);
-        }
-    }
-
 }

--- a/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/ConnectionGenerator.java
+++ b/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/ConnectionGenerator.java
@@ -63,8 +63,13 @@ public class ConnectionGenerator extends AbstractExecutionStage {
     }
 
     @Override
-    protected List<PipelineAgent> getEnabledAgents() {
-        return findByClassName(enabledAgents, agents);
+    public List<String> getEnabledAgentIds() {
+        return enabledAgents;
+    }
+
+    @Override
+    protected List<PipelineAgent> getAllAgents() {
+        return this.agents;
     }
 
     @Override

--- a/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/InitialConnectionAgent.java
+++ b/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/InitialConnectionAgent.java
@@ -33,8 +33,13 @@ public class InitialConnectionAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledInformants, informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledInformants;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 
     @Override

--- a/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/InitialConnectionAgent.java
+++ b/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/InitialConnectionAgent.java
@@ -2,23 +2,16 @@
 package edu.kit.kastel.mcse.ardoco.core.connectiongenerator.agents;
 
 import java.util.List;
-import java.util.SortedMap;
 
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.informants.ExtractionDependentOccurrenceInformant;
 import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.informants.NameTypeConnectionInformant;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 /**
  * The agent that executes the extractors of this stage.
  */
 public class InitialConnectionAgent extends PipelineAgent {
-    private final List<Informant> informants;
-
-    @Configurable
-    private List<String> enabledInformants;
 
     /**
      * Create the agent.
@@ -26,24 +19,7 @@ public class InitialConnectionAgent extends PipelineAgent {
      * @param dataRepository the {@link DataRepository}
      */
     public InitialConnectionAgent(DataRepository dataRepository) {
-        super(InitialConnectionAgent.class.getSimpleName(), dataRepository);
-
-        informants = List.of(new NameTypeConnectionInformant(dataRepository), new ExtractionDependentOccurrenceInformant(dataRepository));
-        enabledInformants = informants.stream().map(e -> e.getClass().getSimpleName()).toList();
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledInformants;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(e -> e.applyConfiguration(additionalConfiguration));
+        super(List.of(new NameTypeConnectionInformant(dataRepository), new ExtractionDependentOccurrenceInformant(dataRepository)), InitialConnectionAgent.class
+                .getSimpleName(), dataRepository);
     }
 }

--- a/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/InstanceConnectionAgent.java
+++ b/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/InstanceConnectionAgent.java
@@ -2,22 +2,15 @@
 package edu.kit.kastel.mcse.ardoco.core.connectiongenerator.agents;
 
 import java.util.List;
-import java.util.SortedMap;
 
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.informants.InstantConnectionInformant;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 /**
  * This connector finds names of model instance in recommended instances.
  */
 public class InstanceConnectionAgent extends PipelineAgent {
-    private final List<Informant> informants;
-
-    @Configurable
-    private List<String> enabledInformants;
 
     /**
      * Create the agent.
@@ -25,24 +18,6 @@ public class InstanceConnectionAgent extends PipelineAgent {
      * @param dataRepository the {@link DataRepository}
      */
     public InstanceConnectionAgent(DataRepository dataRepository) {
-        super(InstanceConnectionAgent.class.getSimpleName(), dataRepository);
-
-        informants = List.of(new InstantConnectionInformant(dataRepository));
-        enabledInformants = informants.stream().map(e -> e.getClass().getSimpleName()).toList();
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledInformants;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(e -> e.applyConfiguration(additionalConfiguration));
+        super(List.of(new InstantConnectionInformant(dataRepository)), InstanceConnectionAgent.class.getSimpleName(), dataRepository);
     }
 }

--- a/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/InstanceConnectionAgent.java
+++ b/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/InstanceConnectionAgent.java
@@ -32,8 +32,13 @@ public class InstanceConnectionAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledInformants, informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledInformants;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 
     @Override

--- a/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/ProjectNameFilterAgent.java
+++ b/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/ProjectNameFilterAgent.java
@@ -2,13 +2,10 @@
 package edu.kit.kastel.mcse.ardoco.core.connectiongenerator.agents;
 
 import java.util.List;
-import java.util.SortedMap;
 
 import edu.kit.kastel.mcse.ardoco.core.api.recommendationgenerator.RecommendedInstance;
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.informants.ProjectNameInformant;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 /**
@@ -17,10 +14,6 @@ import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
  * {@link RecommendedInstance} extremely improbable.
  */
 public class ProjectNameFilterAgent extends PipelineAgent {
-    private final List<Informant> informants;
-
-    @Configurable
-    private List<String> enabledInformants;
 
     /**
      * Create the agent.
@@ -28,24 +21,6 @@ public class ProjectNameFilterAgent extends PipelineAgent {
      * @param dataRepository the {@link DataRepository}
      */
     public ProjectNameFilterAgent(DataRepository dataRepository) {
-        super("ProjectNameFilterAgent", dataRepository);
-
-        informants = List.of(new ProjectNameInformant(dataRepository));
-        enabledInformants = informants.stream().map(e -> e.getClass().getSimpleName()).toList();
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledInformants;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(e -> e.applyConfiguration(additionalConfiguration));
+        super(List.of(new ProjectNameInformant(dataRepository)), "ProjectNameFilterAgent", dataRepository);
     }
 }

--- a/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/ProjectNameFilterAgent.java
+++ b/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/ProjectNameFilterAgent.java
@@ -35,8 +35,13 @@ public class ProjectNameFilterAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledInformants, informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledInformants;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 
     @Override

--- a/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/ReferenceAgent.java
+++ b/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/ReferenceAgent.java
@@ -34,8 +34,13 @@ public class ReferenceAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledInformants, informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledInformants;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 
     @Override

--- a/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/ReferenceAgent.java
+++ b/stages/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/connectiongenerator/agents/ReferenceAgent.java
@@ -2,12 +2,9 @@
 package edu.kit.kastel.mcse.ardoco.core.connectiongenerator.agents;
 
 import java.util.List;
-import java.util.SortedMap;
 
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.connectiongenerator.informants.ReferenceInformant;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 /**
@@ -16,35 +13,12 @@ import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
  */
 public class ReferenceAgent extends PipelineAgent {
 
-    private final List<Informant> informants;
-
-    @Configurable
-    private List<String> enabledInformants;
-
     /**
      * Create the agent.
      *
      * @param dataRepository the {@link DataRepository}
      */
     public ReferenceAgent(DataRepository dataRepository) {
-        super(ReferenceAgent.class.getSimpleName(), dataRepository);
-
-        informants = List.of(new ReferenceInformant(dataRepository));
-        enabledInformants = informants.stream().map(e -> e.getClass().getSimpleName()).toList();
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledInformants;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(e -> e.applyConfiguration(additionalConfiguration));
+        super(List.of(new ReferenceInformant(dataRepository)), ReferenceAgent.class.getSimpleName(), dataRepository);
     }
 }

--- a/stages/diagram-recognition/src/main/kotlin/edu/kit/kastel/mcse/ardoco/lissa/DiagramRecognition.kt
+++ b/stages/diagram-recognition/src/main/kotlin/edu/kit/kastel/mcse/ardoco/lissa/DiagramRecognition.kt
@@ -2,15 +2,13 @@ package edu.kit.kastel.mcse.ardoco.lissa
 
 import edu.kit.kastel.mcse.ardoco.core.api.InputDiagramData
 import edu.kit.kastel.mcse.ardoco.core.api.diagramrecognition.DiagramRecognitionState
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository
 import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractExecutionStage
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent
 import edu.kit.kastel.mcse.ardoco.lissa.diagramrecognition.agents.DiagramRecognitionAgent
 import edu.kit.kastel.mcse.ardoco.lissa.diagramrecognition.model.DiagramImpl
 import java.util.SortedMap
 
-class DiagramRecognition : AbstractExecutionStage {
+class DiagramRecognition(dataRepository: DataRepository) : AbstractExecutionStage(listOf(DiagramRecognitionAgent(dataRepository)), ID, dataRepository) {
 
     companion object {
         const val ID = "DiagramRecognition"
@@ -30,16 +28,6 @@ class DiagramRecognition : AbstractExecutionStage {
         }
     }
 
-    private val agents: List<PipelineAgent>
-
-    @Configurable
-    private var enabledAgents: MutableList<String>
-
-    constructor(dataRepository: DataRepository) : super(ID, dataRepository) {
-        this.agents = listOf(DiagramRecognitionAgent(dataRepository))
-        enabledAgents = this.agents.map { it.id }.toMutableList()
-    }
-
     override fun initializeState() {
         val inputDiagrams = dataRepository.getData(InputDiagramData.ID, InputDiagramData::class.java)
         if (inputDiagrams.isEmpty) {
@@ -53,16 +41,5 @@ class DiagramRecognition : AbstractExecutionStage {
             diagramRecognitionState.addDiagram(diagram)
         }
         dataRepository.addData(DiagramRecognitionState.ID, diagramRecognitionState)
-    }
-
-    public override fun getEnabledAgentIds(): List<String> = enabledAgents
-
-    override fun getAllAgents(): List<PipelineAgent> = agents
-
-    override fun delegateApplyConfigurationToInternalObjects(additionalConfiguration: SortedMap<String?, String?>) {
-        super.delegateApplyConfigurationToInternalObjects(additionalConfiguration)
-        for (agent in agents) {
-            agent.applyConfiguration(additionalConfiguration)
-        }
     }
 }

--- a/stages/diagram-recognition/src/main/kotlin/edu/kit/kastel/mcse/ardoco/lissa/DiagramRecognition.kt
+++ b/stages/diagram-recognition/src/main/kotlin/edu/kit/kastel/mcse/ardoco/lissa/DiagramRecognition.kt
@@ -8,7 +8,7 @@ import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractExecutionStage
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent
 import edu.kit.kastel.mcse.ardoco.lissa.diagramrecognition.agents.DiagramRecognitionAgent
 import edu.kit.kastel.mcse.ardoco.lissa.diagramrecognition.model.DiagramImpl
-import java.util.*
+import java.util.SortedMap
 
 class DiagramRecognition : AbstractExecutionStage {
 
@@ -55,9 +55,9 @@ class DiagramRecognition : AbstractExecutionStage {
         dataRepository.addData(DiagramRecognitionState.ID, diagramRecognitionState)
     }
 
-    override fun getEnabledAgents(): MutableList<PipelineAgent> {
-        return findByClassName(enabledAgents, agents)
-    }
+    public override fun getEnabledAgentIds(): List<String> = enabledAgents
+
+    override fun getAllAgents(): List<PipelineAgent> = agents
 
     override fun delegateApplyConfigurationToInternalObjects(additionalConfiguration: SortedMap<String?, String?>) {
         super.delegateApplyConfigurationToInternalObjects(additionalConfiguration)

--- a/stages/diagram-recognition/src/main/kotlin/edu/kit/kastel/mcse/ardoco/lissa/diagramrecognition/agents/DiagramRecognitionAgent.kt
+++ b/stages/diagram-recognition/src/main/kotlin/edu/kit/kastel/mcse/ardoco/lissa/diagramrecognition/agents/DiagramRecognitionAgent.kt
@@ -8,7 +8,7 @@ import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent
 import edu.kit.kastel.mcse.ardoco.lissa.diagramrecognition.informants.ObjectDetectionInformant
 import edu.kit.kastel.mcse.ardoco.lissa.diagramrecognition.informants.OcrInformant
 import edu.kit.kastel.mcse.ardoco.lissa.diagramrecognition.informants.RecognitionCombinatorInformant
-import java.util.*
+import java.util.SortedMap
 
 /**
  * This agent uses the [DiagramRecognitionState] to extract the diagrams and sketches from images.
@@ -25,11 +25,11 @@ class DiagramRecognitionAgent(dataRepository: DataRepository) : PipelineAgent(ID
     )
 
     @Configurable
-    private var enabledInformants: MutableList<String> =
-        informants.map { e: Informant -> e.javaClass.simpleName }.toMutableList()
+    private var enabledInformants = informants.map { e: Informant -> e.id }.toMutableList()
 
-    override fun getEnabledPipelineSteps(): MutableList<Informant> = findByClassName(enabledInformants, informants)
+    override fun getEnabledPipelineStepIds(): List<String> = enabledInformants
 
+    override fun getAllPipelineSteps(): List<Informant> = informants
     override fun delegateApplyConfigurationToInternalObjects(additionalConfiguration: SortedMap<String?, String?>?) {
         informants.forEach { it.applyConfiguration(additionalConfiguration) }
     }

--- a/stages/diagram-recognition/src/main/kotlin/edu/kit/kastel/mcse/ardoco/lissa/diagramrecognition/agents/DiagramRecognitionAgent.kt
+++ b/stages/diagram-recognition/src/main/kotlin/edu/kit/kastel/mcse/ardoco/lissa/diagramrecognition/agents/DiagramRecognitionAgent.kt
@@ -1,36 +1,25 @@
 package edu.kit.kastel.mcse.ardoco.lissa.diagramrecognition.agents
 
 import edu.kit.kastel.mcse.ardoco.core.api.diagramrecognition.DiagramRecognitionState
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent
 import edu.kit.kastel.mcse.ardoco.lissa.diagramrecognition.informants.ObjectDetectionInformant
 import edu.kit.kastel.mcse.ardoco.lissa.diagramrecognition.informants.OcrInformant
 import edu.kit.kastel.mcse.ardoco.lissa.diagramrecognition.informants.RecognitionCombinatorInformant
-import java.util.SortedMap
 
 /**
  * This agent uses the [DiagramRecognitionState] to extract the diagrams and sketches from images.
  */
-class DiagramRecognitionAgent(dataRepository: DataRepository) : PipelineAgent(ID, dataRepository) {
-    companion object {
-        const val ID = "DiagramRecognitionAgent"
-    }
-
-    private val informants = listOf(
+class DiagramRecognitionAgent(dataRepository: DataRepository) : PipelineAgent(
+    listOf(
         ObjectDetectionInformant(dataRepository),
         OcrInformant(dataRepository),
         RecognitionCombinatorInformant(dataRepository)
-    )
-
-    @Configurable
-    private var enabledInformants = informants.map { e: Informant -> e.id }.toMutableList()
-
-    override fun getEnabledPipelineStepIds(): List<String> = enabledInformants
-
-    override fun getAllPipelineSteps(): List<Informant> = informants
-    override fun delegateApplyConfigurationToInternalObjects(additionalConfiguration: SortedMap<String?, String?>?) {
-        informants.forEach { it.applyConfiguration(additionalConfiguration) }
+    ),
+    ID,
+    dataRepository
+) {
+    companion object {
+        const val ID = "DiagramRecognitionAgent"
     }
 }

--- a/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/InconsistencyChecker.java
+++ b/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/InconsistencyChecker.java
@@ -4,32 +4,18 @@ package edu.kit.kastel.mcse.ardoco.core.inconsistency;
 import java.util.List;
 import java.util.SortedMap;
 
-import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
-
 import edu.kit.kastel.mcse.ardoco.core.api.inconsistency.InconsistencyStates;
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.inconsistency.agents.InitialInconsistencyAgent;
 import edu.kit.kastel.mcse.ardoco.core.inconsistency.agents.MissingModelElementInconsistencyAgent;
 import edu.kit.kastel.mcse.ardoco.core.inconsistency.agents.UndocumentedModelElementInconsistencyAgent;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractExecutionStage;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Agent;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 public class InconsistencyChecker extends AbstractExecutionStage {
 
-    private final MutableList<PipelineAgent> agents;
-
-    @Configurable
-    private List<String> enabledAgents;
-
     public InconsistencyChecker(DataRepository dataRepository) {
-        super("InconsistencyChecker", dataRepository);
-
-        agents = Lists.mutable.of(new InitialInconsistencyAgent(dataRepository), new MissingModelElementInconsistencyAgent(dataRepository),
-                new UndocumentedModelElementInconsistencyAgent(dataRepository));
-        enabledAgents = agents.collect(Agent::getId);
+        super(List.of(new InitialInconsistencyAgent(dataRepository), new MissingModelElementInconsistencyAgent(dataRepository),
+                new UndocumentedModelElementInconsistencyAgent(dataRepository)), "InconsistencyChecker", dataRepository);
     }
 
     /**
@@ -49,24 +35,6 @@ public class InconsistencyChecker extends AbstractExecutionStage {
     protected void initializeState() {
         var inconsistencyStates = InconsistencyStatesImpl.build();
         getDataRepository().addData(InconsistencyStates.ID, inconsistencyStates);
-    }
-
-    @Override
-    public List<String> getEnabledAgentIds() {
-        return enabledAgents;
-    }
-
-    @Override
-    protected List<PipelineAgent> getAllAgents() {
-        return this.agents;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        super.delegateApplyConfigurationToInternalObjects(additionalConfiguration);
-        for (var agent : agents) {
-            agent.applyConfiguration(additionalConfiguration);
-        }
     }
 
 }

--- a/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/InconsistencyChecker.java
+++ b/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/InconsistencyChecker.java
@@ -52,8 +52,13 @@ public class InconsistencyChecker extends AbstractExecutionStage {
     }
 
     @Override
-    protected List<PipelineAgent> getEnabledAgents() {
-        return findByClassName(enabledAgents, agents);
+    public List<String> getEnabledAgentIds() {
+        return enabledAgents;
+    }
+
+    @Override
+    protected List<PipelineAgent> getAllAgents() {
+        return this.agents;
     }
 
     @Override

--- a/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/agents/InitialInconsistencyAgent.java
+++ b/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/agents/InitialInconsistencyAgent.java
@@ -2,33 +2,21 @@
 package edu.kit.kastel.mcse.ardoco.core.inconsistency.agents;
 
 import java.util.List;
-import java.util.SortedMap;
-
-import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
 import edu.kit.kastel.mcse.ardoco.core.common.util.DataRepositoryHelper;
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.inconsistency.informants.OccasionFilter;
 import edu.kit.kastel.mcse.ardoco.core.inconsistency.informants.RecommendedInstanceProbabilityFilter;
 import edu.kit.kastel.mcse.ardoco.core.inconsistency.informants.UnwantedWordsFilter;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 public class InitialInconsistencyAgent extends PipelineAgent {
-    private final MutableList<Informant> filters;
-
-    @Configurable
-    private List<String> enabledFilters;
 
     public InitialInconsistencyAgent(DataRepository dataRepository) {
-        super(InitialInconsistencyAgent.class.getSimpleName(), dataRepository);
+        super(List.of(new RecommendedInstanceProbabilityFilter(dataRepository), new OccasionFilter(dataRepository), new UnwantedWordsFilter(dataRepository)),
+                InitialInconsistencyAgent.class.getSimpleName(), dataRepository);
 
-        filters = Lists.mutable.of(new RecommendedInstanceProbabilityFilter(dataRepository), new OccasionFilter(dataRepository), new UnwantedWordsFilter(
-                dataRepository));
-        enabledFilters = filters.collect(Informant::getId);
     }
 
     @Override
@@ -45,20 +33,5 @@ public class InitialInconsistencyAgent extends PipelineAgent {
 
             inconsistencyState.addRecommendedInstances(recommendationState.getRecommendedInstances().toList());
         }
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledFilters;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return filters;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        filters.forEach(filter -> filter.applyConfiguration(additionalConfiguration));
     }
 }

--- a/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/agents/InitialInconsistencyAgent.java
+++ b/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/agents/InitialInconsistencyAgent.java
@@ -48,8 +48,13 @@ public class InitialInconsistencyAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledFilters, filters);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledFilters;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return filters;
     }
 
     @Override

--- a/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/agents/MissingModelElementInconsistencyAgent.java
+++ b/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/agents/MissingModelElementInconsistencyAgent.java
@@ -25,8 +25,13 @@ public class MissingModelElementInconsistencyAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledInformants, informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledInformants;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 
     @Override

--- a/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/agents/MissingModelElementInconsistencyAgent.java
+++ b/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/agents/MissingModelElementInconsistencyAgent.java
@@ -2,40 +2,14 @@
 package edu.kit.kastel.mcse.ardoco.core.inconsistency.agents;
 
 import java.util.List;
-import java.util.SortedMap;
 
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.inconsistency.informants.MissingModelElementInconsistencyInformant;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 public class MissingModelElementInconsistencyAgent extends PipelineAgent {
-
-    private final List<Informant> informants;
-
-    @Configurable
-    private List<String> enabledInformants;
-
     public MissingModelElementInconsistencyAgent(DataRepository dataRepository) {
-        super(MissingModelElementInconsistencyAgent.class.getSimpleName(), dataRepository);
-
-        informants = List.of(new MissingModelElementInconsistencyInformant(dataRepository));
-        enabledInformants = informants.stream().map(e -> e.getClass().getSimpleName()).toList();
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledInformants;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(e -> e.applyConfiguration(additionalConfiguration));
+        super(List.of(new MissingModelElementInconsistencyInformant(dataRepository)), MissingModelElementInconsistencyAgent.class.getSimpleName(),
+                dataRepository);
     }
 }

--- a/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/agents/UndocumentedModelElementInconsistencyAgent.java
+++ b/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/agents/UndocumentedModelElementInconsistencyAgent.java
@@ -2,12 +2,9 @@
 package edu.kit.kastel.mcse.ardoco.core.inconsistency.agents;
 
 import java.util.List;
-import java.util.SortedMap;
 
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.inconsistency.informants.UndocumentedModelElementInconsistencyInformant;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 /**
@@ -16,30 +13,8 @@ import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
  */
 public class UndocumentedModelElementInconsistencyAgent extends PipelineAgent {
 
-    private final List<Informant> informants;
-
-    @Configurable
-    private List<String> enabledInformants;
-
     public UndocumentedModelElementInconsistencyAgent(DataRepository dataRepository) {
-        super(UndocumentedModelElementInconsistencyAgent.class.getSimpleName(), dataRepository);
-
-        informants = List.of(new UndocumentedModelElementInconsistencyInformant(dataRepository));
-        enabledInformants = informants.stream().map(e -> e.getClass().getSimpleName()).toList();
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledInformants;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(e -> e.applyConfiguration(additionalConfiguration));
+        super(List.of(new UndocumentedModelElementInconsistencyInformant(dataRepository)), UndocumentedModelElementInconsistencyAgent.class.getSimpleName(),
+                dataRepository);
     }
 }

--- a/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/agents/UndocumentedModelElementInconsistencyAgent.java
+++ b/stages/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/core/inconsistency/agents/UndocumentedModelElementInconsistencyAgent.java
@@ -29,8 +29,13 @@ public class UndocumentedModelElementInconsistencyAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledInformants, informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledInformants;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 
     @Override

--- a/stages/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/models/ArCoTLModelProviderAgent.java
+++ b/stages/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/models/ArCoTLModelProviderAgent.java
@@ -2,7 +2,6 @@
 package edu.kit.kastel.mcse.ardoco.core.models;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedMap;
 
@@ -16,7 +15,6 @@ import edu.kit.kastel.mcse.ardoco.core.models.connectors.generators.architecture
 import edu.kit.kastel.mcse.ardoco.core.models.connectors.generators.code.AllLanguagesExtractor;
 import edu.kit.kastel.mcse.ardoco.core.models.connectors.generators.code.CodeExtractor;
 import edu.kit.kastel.mcse.ardoco.core.models.informants.ArCoTLModelProviderInformant;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractPipelineStep;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
@@ -24,8 +22,6 @@ import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
  * Agent that provides information from models.
  */
 public class ArCoTLModelProviderAgent extends PipelineAgent {
-
-    private final List<Informant> informants;
 
     /**
      * Instantiates a new model provider agent.
@@ -35,11 +31,11 @@ public class ArCoTLModelProviderAgent extends PipelineAgent {
      * @param extractors the list of ModelConnectors that should be used
      */
     public ArCoTLModelProviderAgent(DataRepository data, List<Extractor> extractors) {
-        super(ArCoTLModelProviderAgent.class.getSimpleName(), data);
-        informants = new ArrayList<>();
-        for (var extractor : extractors) {
-            informants.add(new ArCoTLModelProviderInformant(data, extractor));
-        }
+        super(informants(data, extractors), ArCoTLModelProviderAgent.class.getSimpleName(), data);
+    }
+
+    private static List<? extends Informant> informants(DataRepository data, List<Extractor> extractors) {
+        return extractors.stream().map(e -> new ArCoTLModelProviderInformant(data, e)).toList();
     }
 
     public static ArCoTLModelProviderAgent get(File inputArchitectureModel, ArchitectureModelType architectureModelType, File inputCode,
@@ -58,15 +54,5 @@ public class ArCoTLModelProviderAgent extends PipelineAgent {
     @Override
     protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
         // empty
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return informants.stream().map(AbstractPipelineStep::getId).toList();
     }
 }

--- a/stages/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/models/ArCoTLModelProviderAgent.java
+++ b/stages/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/models/ArCoTLModelProviderAgent.java
@@ -16,6 +16,7 @@ import edu.kit.kastel.mcse.ardoco.core.models.connectors.generators.architecture
 import edu.kit.kastel.mcse.ardoco.core.models.connectors.generators.code.AllLanguagesExtractor;
 import edu.kit.kastel.mcse.ardoco.core.models.connectors.generators.code.CodeExtractor;
 import edu.kit.kastel.mcse.ardoco.core.models.informants.ArCoTLModelProviderInformant;
+import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractPipelineStep;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
@@ -60,7 +61,12 @@ public class ArCoTLModelProviderAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return new ArrayList<>(informants);
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
+    }
+
+    @Override
+    protected List<String> getEnabledPipelineStepIds() {
+        return informants.stream().map(AbstractPipelineStep::getId).toList();
     }
 }

--- a/stages/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/models/ModelProviderAgent.java
+++ b/stages/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/models/ModelProviderAgent.java
@@ -3,12 +3,11 @@ package edu.kit.kastel.mcse.ardoco.core.models;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.SortedMap;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.ArchitectureModelType;
 import edu.kit.kastel.mcse.ardoco.core.api.models.ModelConnector;
+import edu.kit.kastel.mcse.ardoco.core.configuration.NoConfiguration;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.models.connectors.PcmXmlModelConnector;
 import edu.kit.kastel.mcse.ardoco.core.models.connectors.UmlModelConnector;
@@ -20,9 +19,8 @@ import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 /**
  * Agent that provides information from models.
  */
+@NoConfiguration
 public class ModelProviderAgent extends PipelineAgent {
-
-    private final List<Informant> informants;
 
     /**
      * Instantiates a new model provider agent.
@@ -32,17 +30,15 @@ public class ModelProviderAgent extends PipelineAgent {
      * @param modelConnectors the list of ModelConnectors that should be used
      */
     public ModelProviderAgent(DataRepository data, List<ModelConnector> modelConnectors) {
-        super(ModelProviderAgent.class.getSimpleName(), data);
-        informants = new ArrayList<>();
-        for (var modelConnector : modelConnectors) {
-            informants.add(new ModelProviderInformant(data, modelConnector));
-        }
+        super(informants(modelConnectors, data), ModelProviderAgent.class.getSimpleName(), data);
+    }
+
+    private static List<? extends Informant> informants(List<ModelConnector> modelConnectors, DataRepository data) {
+        return modelConnectors.stream().map(e -> new ModelProviderInformant(data, e)).toList();
     }
 
     private ModelProviderAgent(DataRepository data, LegacyCodeModelInformant codeModelInformant) {
-        super(ModelProviderAgent.class.getSimpleName(), data);
-        informants = new ArrayList<>();
-        informants.add(codeModelInformant);
+        super(List.of(codeModelInformant), ModelProviderAgent.class.getSimpleName(), data);
     }
 
     /**
@@ -65,20 +61,5 @@ public class ModelProviderAgent extends PipelineAgent {
 
     public static ModelProviderAgent getCodeProvider(DataRepository dataRepository) {
         return new ModelProviderAgent(dataRepository, new LegacyCodeModelInformant(dataRepository));
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(e -> e.applyConfiguration(additionalConfiguration));
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return informants.stream().map(Informant::getId).toList();
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
     }
 }

--- a/stages/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/models/ModelProviderAgent.java
+++ b/stages/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/core/models/ModelProviderAgent.java
@@ -73,7 +73,12 @@ public class ModelProviderAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return new ArrayList<>(informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return informants.stream().map(Informant::getId).toList();
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 }

--- a/stages/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/RecommendationGenerator.java
+++ b/stages/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/RecommendationGenerator.java
@@ -1,18 +1,13 @@
 /* Licensed under MIT 2021-2023. */
 package edu.kit.kastel.mcse.ardoco.core.recommendationgenerator;
 
-import java.util.List;
 import java.util.SortedMap;
 
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
 
 import edu.kit.kastel.mcse.ardoco.core.api.recommendationgenerator.RecommendationStates;
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractExecutionStage;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Agent;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 import edu.kit.kastel.mcse.ardoco.core.recommendationgenerator.agents.InitialRecommendationAgent;
 import edu.kit.kastel.mcse.ardoco.core.recommendationgenerator.agents.PhraseRecommendationAgent;
 
@@ -21,24 +16,15 @@ import edu.kit.kastel.mcse.ardoco.core.recommendationgenerator.agents.PhraseReco
  */
 public class RecommendationGenerator extends AbstractExecutionStage {
 
-    private final MutableList<PipelineAgent> agents;
-
-    @Configurable
-    private List<String> enabledAgents;
-
     /**
      * Creates a new model connection agent with the given extraction state and ntr state.
      */
     public RecommendationGenerator(DataRepository dataRepository) {
-        super("RecommendationGenerator", dataRepository);
-
-        this.agents = Lists.mutable.of(//
+        super(Lists.mutable.of(//
                 //new TermBuilder(dataRepository),//
                 new InitialRecommendationAgent(dataRepository),//
-                new PhraseRecommendationAgent(dataRepository)
-
-        );
-        this.enabledAgents = agents.collect(Agent::getId);
+                new PhraseRecommendationAgent(dataRepository)),//
+                RecommendationGenerator.class.getSimpleName(), dataRepository);
     }
 
     /**
@@ -58,23 +44,5 @@ public class RecommendationGenerator extends AbstractExecutionStage {
     protected void initializeState() {
         var recommendationStates = RecommendationStatesImpl.build();
         getDataRepository().addData(RecommendationStates.ID, recommendationStates);
-    }
-
-    @Override
-    public List<String> getEnabledAgentIds() {
-        return enabledAgents;
-    }
-
-    @Override
-    protected List<PipelineAgent> getAllAgents() {
-        return this.agents;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        super.delegateApplyConfigurationToInternalObjects(additionalConfiguration);
-        for (var agent : agents) {
-            agent.applyConfiguration(additionalConfiguration);
-        }
     }
 }

--- a/stages/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/RecommendationGenerator.java
+++ b/stages/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/RecommendationGenerator.java
@@ -61,8 +61,13 @@ public class RecommendationGenerator extends AbstractExecutionStage {
     }
 
     @Override
-    protected List<PipelineAgent> getEnabledAgents() {
-        return findByClassName(enabledAgents, agents);
+    public List<String> getEnabledAgentIds() {
+        return enabledAgents;
+    }
+
+    @Override
+    protected List<PipelineAgent> getAllAgents() {
+        return this.agents;
     }
 
     @Override

--- a/stages/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/agents/InitialRecommendationAgent.java
+++ b/stages/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/agents/InitialRecommendationAgent.java
@@ -2,11 +2,8 @@
 package edu.kit.kastel.mcse.ardoco.core.recommendationgenerator.agents;
 
 import java.util.List;
-import java.util.SortedMap;
 
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 import edu.kit.kastel.mcse.ardoco.core.recommendationgenerator.informants.NameTypeInformant;
 
@@ -14,30 +11,7 @@ import edu.kit.kastel.mcse.ardoco.core.recommendationgenerator.informants.NameTy
  * The Class InitialRecommendationAgent runs all extractors of this stage.
  */
 public class InitialRecommendationAgent extends PipelineAgent {
-
-    private final List<Informant> informants;
-
-    @Configurable
-    private List<String> enabledInformants;
-
     public InitialRecommendationAgent(DataRepository dataRepository) {
-        super(InitialRecommendationAgent.class.getSimpleName(), dataRepository);
-        informants = List.of(new NameTypeInformant(dataRepository));
-        enabledInformants = informants.stream().map(e -> e.getClass().getSimpleName()).toList();
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledInformants;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(e -> e.applyConfiguration(additionalConfiguration));
+        super(List.of(new NameTypeInformant(dataRepository)), InitialRecommendationAgent.class.getSimpleName(), dataRepository);
     }
 }

--- a/stages/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/agents/InitialRecommendationAgent.java
+++ b/stages/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/agents/InitialRecommendationAgent.java
@@ -27,8 +27,13 @@ public class InitialRecommendationAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledInformants, informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledInformants;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 
     @Override

--- a/stages/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/agents/PhraseRecommendationAgent.java
+++ b/stages/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/agents/PhraseRecommendationAgent.java
@@ -25,8 +25,13 @@ public final class PhraseRecommendationAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledInformants, informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledInformants;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 
     @Override

--- a/stages/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/agents/PhraseRecommendationAgent.java
+++ b/stages/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/core/recommendationgenerator/agents/PhraseRecommendationAgent.java
@@ -2,40 +2,14 @@
 package edu.kit.kastel.mcse.ardoco.core.recommendationgenerator.agents;
 
 import java.util.List;
-import java.util.SortedMap;
 
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 import edu.kit.kastel.mcse.ardoco.core.recommendationgenerator.informants.CompoundRecommendationInformant;
 
 public final class PhraseRecommendationAgent extends PipelineAgent {
 
-    private final List<Informant> informants;
-
-    @Configurable
-    private List<String> enabledInformants;
-
     public PhraseRecommendationAgent(DataRepository dataRepository) {
-        super(PhraseRecommendationAgent.class.getSimpleName(), dataRepository);
-
-        informants = List.of(new CompoundRecommendationInformant(dataRepository));
-        enabledInformants = informants.stream().map(e -> e.getClass().getSimpleName()).toList();
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledInformants;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(e -> e.applyConfiguration(additionalConfiguration));
+        super(List.of(new CompoundRecommendationInformant(dataRepository)), PhraseRecommendationAgent.class.getSimpleName(), dataRepository);
     }
 }

--- a/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/TextExtraction.java
+++ b/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/TextExtraction.java
@@ -61,8 +61,13 @@ public class TextExtraction extends AbstractExecutionStage {
     }
 
     @Override
-    protected List<PipelineAgent> getEnabledAgents() {
-        return findByClassName(enabledAgents, agents);
+    public List<String> getEnabledAgentIds() {
+        return enabledAgents;
+    }
+
+    @Override
+    protected List<PipelineAgent> getAllAgents() {
+        return this.agents;
     }
 
     @Override

--- a/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/TextExtraction.java
+++ b/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/TextExtraction.java
@@ -4,15 +4,9 @@ package edu.kit.kastel.mcse.ardoco.core.textextraction;
 import java.util.List;
 import java.util.SortedMap;
 
-import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
-
 import edu.kit.kastel.mcse.ardoco.core.api.textextraction.TextState;
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractExecutionStage;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Agent;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 import edu.kit.kastel.mcse.ardoco.core.textextraction.agents.InitialTextAgent;
 import edu.kit.kastel.mcse.ardoco.core.textextraction.agents.PhraseAgent;
 
@@ -21,20 +15,12 @@ import edu.kit.kastel.mcse.ardoco.core.textextraction.agents.PhraseAgent;
  */
 public class TextExtraction extends AbstractExecutionStage {
 
-    private final MutableList<PipelineAgent> agents;
-
-    @Configurable
-    private List<String> enabledAgents;
-
     /**
      * Instantiates a new text extractor.
      */
     public TextExtraction(DataRepository dataRepository) {
-        super("TextExtraction", dataRepository);
-        this.agents = Lists.mutable.of(//
-                new InitialTextAgent(dataRepository),//
-                new PhraseAgent(dataRepository));
-        this.enabledAgents = agents.collect(Agent::getId);
+        super(List.of(new InitialTextAgent(dataRepository), new PhraseAgent(dataRepository)), TextExtraction.class.getSimpleName(), dataRepository);
+
     }
 
     /**
@@ -57,24 +43,6 @@ public class TextExtraction extends AbstractExecutionStage {
         if (optionalTextState.isEmpty()) {
             var textState = new TextStateImpl();
             dataRepository.addData(TextState.ID, textState);
-        }
-    }
-
-    @Override
-    public List<String> getEnabledAgentIds() {
-        return enabledAgents;
-    }
-
-    @Override
-    protected List<PipelineAgent> getAllAgents() {
-        return this.agents;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        super.delegateApplyConfigurationToInternalObjects(additionalConfiguration);
-        for (var agent : agents) {
-            agent.applyConfiguration(additionalConfiguration);
         }
     }
 }

--- a/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/InitialTextAgent.java
+++ b/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/InitialTextAgent.java
@@ -2,12 +2,8 @@
 package edu.kit.kastel.mcse.ardoco.core.textextraction.agents;
 
 import java.util.List;
-import java.util.SortedMap;
 
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractPipelineStep;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 import edu.kit.kastel.mcse.ardoco.core.textextraction.informants.InDepArcsInformant;
 import edu.kit.kastel.mcse.ardoco.core.textextraction.informants.NounInformant;
@@ -19,34 +15,13 @@ import edu.kit.kastel.mcse.ardoco.core.textextraction.informants.SeparatedNamesI
  */
 public class InitialTextAgent extends PipelineAgent {
 
-    private final List<Informant> informants;
-
-    @Configurable
-    private List<String> enabledInformants;
-
     /**
      * Instantiates a new initial text agent.
      *
      * @param data the {@link DataRepository}
      */
     public InitialTextAgent(DataRepository data) {
-        super(InitialTextAgent.class.getSimpleName(), data);
-        informants = List.of(new NounInformant(data), new InDepArcsInformant(data), new OutDepArcsInformant(data), new SeparatedNamesInformant(data));
-        enabledInformants = informants.stream().map(AbstractPipelineStep::getId).toList();
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(e -> e.applyConfiguration(additionalConfiguration));
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledInformants;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
+        super(List.of(new NounInformant(data), new InDepArcsInformant(data), new OutDepArcsInformant(data), new SeparatedNamesInformant(data)),
+                InitialTextAgent.class.getSimpleName(), data);
     }
 }

--- a/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/InitialTextAgent.java
+++ b/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/InitialTextAgent.java
@@ -41,7 +41,12 @@ public class InitialTextAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledInformants, informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledInformants;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 }

--- a/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/MappingCombiner.java
+++ b/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/MappingCombiner.java
@@ -25,8 +25,13 @@ public class MappingCombiner extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledInformants, informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledInformants;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 
     @Override

--- a/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/MappingCombiner.java
+++ b/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/MappingCombiner.java
@@ -2,40 +2,13 @@
 package edu.kit.kastel.mcse.ardoco.core.textextraction.agents;
 
 import java.util.List;
-import java.util.SortedMap;
 
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractPipelineStep;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 import edu.kit.kastel.mcse.ardoco.core.textextraction.informants.MappingCombinerInformant;
 
 public class MappingCombiner extends PipelineAgent {
-
-    private final List<Informant> informants;
-
-    @Configurable
-    private List<String> enabledInformants;
-
     public MappingCombiner(DataRepository dataRepository) {
-        super(MappingCombiner.class.getSimpleName(), dataRepository);
-        informants = List.of(new MappingCombinerInformant(dataRepository));
-        enabledInformants = informants.stream().map(AbstractPipelineStep::getId).toList();
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledInformants;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(e -> e.applyConfiguration(additionalConfiguration));
+        super(List.of(new MappingCombinerInformant(dataRepository)), MappingCombiner.class.getSimpleName(), dataRepository);
     }
 }

--- a/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/PhraseAgent.java
+++ b/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/PhraseAgent.java
@@ -2,13 +2,9 @@
 package edu.kit.kastel.mcse.ardoco.core.textextraction.agents;
 
 import java.util.List;
-import java.util.SortedMap;
 
 import edu.kit.kastel.mcse.ardoco.core.api.textextraction.NounMapping;
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractPipelineStep;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 import edu.kit.kastel.mcse.ardoco.core.textextraction.informants.CompoundAgentInformant;
 
@@ -17,35 +13,13 @@ import edu.kit.kastel.mcse.ardoco.core.textextraction.informants.CompoundAgentIn
  */
 public class PhraseAgent extends PipelineAgent {
 
-    private final List<Informant> informants;
-
-    @Configurable
-    private List<String> enabledInformants;
-
     /**
      * Instantiates a new initial text agent.
      *
      * @param dataRepository the {@link DataRepository}
      */
     public PhraseAgent(DataRepository dataRepository) {
-        super(PhraseAgent.class.getSimpleName(), dataRepository);
-        informants = List.of(new CompoundAgentInformant(dataRepository));
-        enabledInformants = informants.stream().map(AbstractPipelineStep::getId).toList();
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledInformants;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(e -> e.applyConfiguration(additionalConfiguration));
+        super(List.of(new CompoundAgentInformant(dataRepository)), PhraseAgent.class.getSimpleName(), dataRepository);
     }
 
 }

--- a/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/PhraseAgent.java
+++ b/stages/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/core/textextraction/agents/PhraseAgent.java
@@ -34,8 +34,13 @@ public class PhraseAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledInformants, informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledInformants;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 
     @Override

--- a/stages/text-preprocessing/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/TextPreprocessingAgent.java
+++ b/stages/text-preprocessing/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/TextPreprocessingAgent.java
@@ -5,19 +5,11 @@ import java.util.List;
 import java.util.SortedMap;
 
 import edu.kit.kastel.mcse.ardoco.core.api.text.NlpInformant;
-import edu.kit.kastel.mcse.ardoco.core.configuration.Configurable;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractPipelineStep;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 import edu.kit.kastel.mcse.ardoco.core.text.providers.informants.corenlp.CoreNLPProvider;
 
 public class TextPreprocessingAgent extends PipelineAgent {
-
-    private final List<Informant> informants;
-
-    @Configurable
-    private List<String> enabledInformants;
 
     /**
      * Instantiates a new initial text agent.
@@ -25,9 +17,7 @@ public class TextPreprocessingAgent extends PipelineAgent {
      * @param data the {@link DataRepository}
      */
     public TextPreprocessingAgent(DataRepository data) {
-        super(TextPreprocessingAgent.class.getSimpleName(), data);
-        informants = List.of(new CoreNLPProvider(data));
-        enabledInformants = informants.stream().map(AbstractPipelineStep::getId).toList();
+        super(List.of(new CoreNLPProvider(data)), TextPreprocessingAgent.class.getSimpleName(), data);
     }
 
     /**
@@ -41,20 +31,5 @@ public class TextPreprocessingAgent extends PipelineAgent {
         var textProvider = new TextPreprocessingAgent(dataRepository);
         textProvider.applyConfiguration(additionalConfigs);
         return textProvider;
-    }
-
-    @Override
-    protected void delegateApplyConfigurationToInternalObjects(SortedMap<String, String> additionalConfiguration) {
-        informants.forEach(e -> e.applyConfiguration(additionalConfiguration));
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return enabledInformants;
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return informants;
     }
 }

--- a/stages/text-preprocessing/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/TextPreprocessingAgent.java
+++ b/stages/text-preprocessing/src/main/java/edu/kit/kastel/mcse/ardoco/core/text/providers/TextPreprocessingAgent.java
@@ -49,7 +49,12 @@ public class TextPreprocessingAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
-        return findByClassName(enabledInformants, informants);
+    protected List<String> getEnabledPipelineStepIds() {
+        return enabledInformants;
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
+        return informants;
     }
 }

--- a/tests/tests-base/src/main/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/ConfigurationTestBase.java
+++ b/tests/tests-base/src/main/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/ConfigurationTestBase.java
@@ -90,7 +90,7 @@ public abstract class ConfigurationTestBase {
     private void fillConfigs(AbstractConfigurable object, List<Field> fields, Map<String, String> configs) throws IllegalAccessException {
         for (Field f : fields) {
             f.setAccessible(true);
-            var key = f.getDeclaringClass().getSimpleName() + AbstractConfigurable.CLASS_ATTRIBUTE_CONNECTOR + f.getName();
+            var key = AbstractConfigurable.getKeyOfField(object, f.getDeclaringClass(), f);
             var rawValue = f.get(object);
             var value = getValue(rawValue);
             if (configs.containsKey(key)) {

--- a/tests/tests-inconsistency/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/baseline/InconsistencyBaseline.java
+++ b/tests/tests-inconsistency/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/baseline/InconsistencyBaseline.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.AbstractExecutionStage;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 /**
  * Baseline approach for inconsistency detection
@@ -13,21 +12,11 @@ import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 public class InconsistencyBaseline extends AbstractExecutionStage {
 
     public InconsistencyBaseline(DataRepository dataRepository) {
-        super("InconsistencyBaseline", dataRepository);
+        super(List.of(new InconsistencyBaselineAgent(dataRepository)), "InconsistencyBaseline", dataRepository);
     }
 
     @Override
     protected void initializeState() {
         // do nothing
-    }
-
-    @Override
-    public List<String> getEnabledAgentIds() {
-        return List.of(InconsistencyBaselineAgent.class.getSimpleName());
-    }
-
-    @Override
-    protected List<PipelineAgent> getAllAgents() {
-        return List.of(new InconsistencyBaselineAgent(getDataRepository()));
     }
 }

--- a/tests/tests-inconsistency/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/baseline/InconsistencyBaseline.java
+++ b/tests/tests-inconsistency/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/baseline/InconsistencyBaseline.java
@@ -22,7 +22,12 @@ public class InconsistencyBaseline extends AbstractExecutionStage {
     }
 
     @Override
-    protected List<PipelineAgent> getEnabledAgents() {
+    public List<String> getEnabledAgentIds() {
+        return List.of(InconsistencyBaselineAgent.class.getSimpleName());
+    }
+
+    @Override
+    protected List<PipelineAgent> getAllAgents() {
         return List.of(new InconsistencyBaselineAgent(getDataRepository()));
     }
 }

--- a/tests/tests-inconsistency/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/baseline/InconsistencyBaselineAgent.java
+++ b/tests/tests-inconsistency/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/baseline/InconsistencyBaselineAgent.java
@@ -17,7 +17,12 @@ public class InconsistencyBaselineAgent extends PipelineAgent {
     }
 
     @Override
-    protected List<Informant> getEnabledPipelineSteps() {
+    protected List<String> getEnabledPipelineStepIds() {
+        return List.of(InconsistencyBaselineInformant.class.getSimpleName());
+    }
+
+    @Override
+    protected List<Informant> getAllPipelineSteps() {
         return List.of(new InconsistencyBaselineInformant(getDataRepository()));
     }
 }

--- a/tests/tests-inconsistency/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/baseline/InconsistencyBaselineAgent.java
+++ b/tests/tests-inconsistency/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/baseline/InconsistencyBaselineAgent.java
@@ -4,25 +4,13 @@ package edu.kit.kastel.mcse.ardoco.core.tests.eval.baseline;
 import java.util.List;
 
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
-import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 
 /**
  * Agent for {@link InconsistencyBaseline}
  */
 public class InconsistencyBaselineAgent extends PipelineAgent {
-
     protected InconsistencyBaselineAgent(DataRepository dataRepository) {
-        super(InconsistencyBaselineAgent.class.getSimpleName(), dataRepository);
-    }
-
-    @Override
-    protected List<String> getEnabledPipelineStepIds() {
-        return List.of(InconsistencyBaselineInformant.class.getSimpleName());
-    }
-
-    @Override
-    protected List<Informant> getAllPipelineSteps() {
-        return List.of(new InconsistencyBaselineInformant(getDataRepository()));
+        super(List.of(new InconsistencyBaselineInformant(dataRepository)), InconsistencyBaselineAgent.class.getSimpleName(), dataRepository);
     }
 }


### PR DESCRIPTION
This PR introduces `ChildClassConfigurables` if a field is marked as `Configurable` and `ChildClassConfigurable` it's configuration key will be determined by the actual object (runtime) and not using the declaring class of the configurable field.

This means, we can highly simplify our agents and pipeline stages by defining logic for enabling informants / agents only one time (in the base class)