### PR TITLE
Remove empty lines in gold standard loading

### DIFF
--- a/tests/tests-base/src/main/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/CodeProject.java
+++ b/tests/tests-base/src/main/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/CodeProject.java
@@ -156,6 +156,7 @@ public enum CodeProject {
             String codeElementId = parts[2];
             goldStandard.add(TraceLinkUtilities.createTraceLinkString(modelElementId, codeElementId));
         }
+        goldStandard.removeIf(String::isBlank);
         return goldStandard.toImmutable();
     }
 

--- a/tests/tests-base/src/main/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/Project.java
+++ b/tests/tests-base/src/main/java/edu/kit/kastel/mcse/ardoco/core/tests/eval/Project.java
@@ -214,6 +214,7 @@ public enum Project {
             logger.error(e.getMessage(), e);
         }
         goldLinks.remove(0);
+        goldLinks.removeIf(String::isBlank);
         return Lists.immutable.ofAll(goldLinks);
     }
 
@@ -236,6 +237,7 @@ public enum Project {
             logger.error(e.getMessage(), e);
         }
         goldLinks.remove("missingModelElementID");
+        goldLinks.removeIf(String::isBlank);
         return Lists.mutable.ofAll(goldLinks);
     }
 


### PR DESCRIPTION
Due to a minor bug, empty lines in the CSVs of goldstandards were not properly omitted. As such, the goldstandards (in some cases like historical TeaStore UME) expected more than intended because of the empty line (that naturally was never in the results. This bug is fixed now by removing blank lines when loading goldstandard files.