### PR TITLE
Bugfix: Set outputs of test to target folder (remove from resources)

### DIFF
--- a/pipeline/pipeline-core/src/test/java/edu/kit/kastel/mcse/ardoco/core/execution/RunnerBaseTest.java
+++ b/pipeline/pipeline-core/src/test/java/edu/kit/kastel/mcse/ardoco/core/execution/RunnerBaseTest.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -22,12 +22,12 @@ public class RunnerBaseTest {
     protected static final String INPUT_TEXT = "../pipeline-core/src/test/resources/teastore.txt";
     protected static final String INPUT_MODEL_ARCHITECTURE = "../pipeline-core/src/test/resources/teastore.repository";
     protected static final String INPUT_MODEL_ARCHITECTURE_UML = "../pipeline-core/src/test/resources/teastore.uml";
-    protected static final String OUTPUT_DIR = "../target/testout";
+    protected final String OUTPUT_DIR = "../target/testout-" + this.getClass().getSimpleName();
     protected static final String ADDITIONAL_CONFIGS = "../pipeline-core/src/test/resources/additionalConfig.txt";
     protected static final String PROJECT_NAME = "teastore";
 
-    @BeforeAll
-    static void setup() {
+    @BeforeEach
+    void setupDirectories() {
         new File(OUTPUT_DIR).mkdirs();
     }
 

--- a/pipeline/pipeline-core/src/test/java/edu/kit/kastel/mcse/ardoco/core/execution/RunnerBaseTest.java
+++ b/pipeline/pipeline-core/src/test/java/edu/kit/kastel/mcse/ardoco/core/execution/RunnerBaseTest.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023. */
+/* Licensed under MIT 2023-2024. */
 package edu.kit.kastel.mcse.ardoco.core.execution;
 
 import java.io.File;
@@ -21,7 +21,7 @@ public class RunnerBaseTest {
     protected static final String INPUT_TEXT = "../pipeline-core/src/test/resources/teastore.txt";
     protected static final String INPUT_MODEL_ARCHITECTURE = "../pipeline-core/src/test/resources/teastore.repository";
     protected static final String INPUT_MODEL_ARCHITECTURE_UML = "../pipeline-core/src/test/resources/teastore.uml";
-    protected static final String OUTPUT_DIR = "../pipeline-core/src/test/resources/testout";
+    protected static final String OUTPUT_DIR = "../target/testout";
     protected static final String ADDITIONAL_CONFIGS = "../pipeline-core/src/test/resources/additionalConfig.txt";
     protected static final String PROJECT_NAME = "teastore";
 

--- a/pipeline/pipeline-core/src/test/java/edu/kit/kastel/mcse/ardoco/core/execution/RunnerBaseTest.java
+++ b/pipeline/pipeline-core/src/test/java/edu/kit/kastel/mcse/ardoco/core/execution/RunnerBaseTest.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -24,6 +25,11 @@ public class RunnerBaseTest {
     protected static final String OUTPUT_DIR = "../target/testout";
     protected static final String ADDITIONAL_CONFIGS = "../pipeline-core/src/test/resources/additionalConfig.txt";
     protected static final String PROJECT_NAME = "teastore";
+
+    @BeforeAll
+    static void setup() {
+        new File(OUTPUT_DIR).mkdirs();
+    }
 
     @AfterEach
     void cleanUp() {

--- a/stages/diagram-consistency/src/test/java/edu/kit/kastel/mcse/ardoco/core/diagramconsistency/evaluation/EvaluationTestBase.java
+++ b/stages/diagram-consistency/src/test/java/edu/kit/kastel/mcse/ardoco/core/diagramconsistency/evaluation/EvaluationTestBase.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023. */
+/* Licensed under MIT 2023-2024. */
 package edu.kit.kastel.mcse.ardoco.core.diagramconsistency.evaluation;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -51,8 +51,8 @@ public class EvaluationTestBase {
     protected static final double PARTIAL_SELECTION_MAX = 0.25;
     protected static final double REFACTORING_RATIO = 0.25;
 
-    protected static final String PIPELINE_OUTPUT = "src/test/resources/pipeline_out";
-    protected static final String TEST_OUTPUT = "src/test/resources/test_out";
+    protected static final String PIPELINE_OUTPUT = "target/pipeline_out";
+    protected static final String TEST_OUTPUT = "target/test_out";
     protected static final Logger logger = LoggerFactory.getLogger(EvaluationTestBase.class);
 
     protected FileWriter writer;

--- a/tests/tests-inconsistency/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/InconsistencyDetectionEvaluationIT.java
+++ b/tests/tests-inconsistency/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/InconsistencyDetectionEvaluationIT.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2021-2023. */
+/* Licensed under MIT 2021-2024. */
 package edu.kit.kastel.mcse.ardoco.core.tests.integration;
 
 import java.io.IOException;
@@ -58,7 +58,7 @@ import edu.kit.kastel.mcse.ardoco.core.tests.integration.inconsistencyhelper.Hol
 class InconsistencyDetectionEvaluationIT {
     private static final Logger logger = LoggerFactory.getLogger(InconsistencyDetectionEvaluationIT.class);
 
-    private static final String OUTPUT = "src/test/resources/testout";
+    private static final String OUTPUT = "target/testout";
     public static final String DIRECTORY_NAME = "ardoco_eval_id";
 
     /**

--- a/tests/tests-misc/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/statehelper/ChangedStatesTest.java
+++ b/tests/tests-misc/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/statehelper/ChangedStatesTest.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2022-2023. */
+/* Licensed under MIT 2022-2024. */
 package edu.kit.kastel.mcse.ardoco.core.tests.integration.statehelper;
 
 import java.io.File;
@@ -34,7 +34,7 @@ public class ChangedStatesTest {
     private static final boolean OVERWRITE_PREVIOUS = false;
     private static final Logger logger = LoggerFactory.getLogger(ChangedStatesTest.class);
 
-    private static final String OUTPUT = "src/test/resources/testout";
+    private static final String OUTPUT = "target/testout";
     private static final Path OUTPUT_PATH = Path.of(OUTPUT);
     private static final Map<Project, ArDoCoResult> DATA_MAP = new LinkedHashMap<>();
     private static final String LOGGING_ARDOCO_CORE = "org.slf4j.simpleLogger.log.edu.kit.kastel.mcse.ardoco.core";

--- a/tests/tests-tlr/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceLinkEvaluationIT.java
+++ b/tests/tests-tlr/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceLinkEvaluationIT.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023. */
+/* Licensed under MIT 2023-2024. */
 package edu.kit.kastel.mcse.ardoco.core.tests.integration;
 
 import static edu.kit.kastel.mcse.ardoco.core.tests.eval.ProjectHelper.ANALYZE_CODE_DIRECTLY;
@@ -57,7 +57,7 @@ class TraceLinkEvaluationIT {
 
     protected static final Logger logger = LoggerFactory.getLogger(TraceLinkEvaluationIT.class);
 
-    protected static final String OUTPUT = "src/test/resources/testout";
+    protected static final String OUTPUT = "target/testout";
 
     protected static final String LOGGING_ARDOCO_CORE = "org.slf4j.simpleLogger.log.edu.kit.kastel.mcse.ardoco.core";
     protected static AtomicBoolean analyzeCodeDirectly = ANALYZE_CODE_DIRECTLY;

--- a/tests/tests-tlr/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceLinkEvaluationIT.java
+++ b/tests/tests-tlr/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceLinkEvaluationIT.java
@@ -57,7 +57,7 @@ class TraceLinkEvaluationIT {
 
     protected static final Logger logger = LoggerFactory.getLogger(TraceLinkEvaluationIT.class);
 
-    protected static final String OUTPUT = "target/testout";
+    protected static final String OUTPUT = "target/testout-tlr-it";
 
     protected static final String LOGGING_ARDOCO_CORE = "org.slf4j.simpleLogger.log.edu.kit.kastel.mcse.ardoco.core";
     protected static AtomicBoolean analyzeCodeDirectly = ANALYZE_CODE_DIRECTLY;

--- a/tests/tests-tlr/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceLinkEvaluationSadCodeDirectIT.java
+++ b/tests/tests-tlr/src/test/java/edu/kit/kastel/mcse/ardoco/core/tests/integration/TraceLinkEvaluationSadCodeDirectIT.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023. */
+/* Licensed under MIT 2023-2024. */
 package edu.kit.kastel.mcse.ardoco.core.tests.integration;
 
 import static edu.kit.kastel.mcse.ardoco.core.tests.eval.ProjectHelper.ANALYZE_CODE_DIRECTLY;
@@ -42,7 +42,7 @@ import edu.kit.kastel.mcse.ardoco.core.tests.integration.tlrhelper.files.TLSumma
 class TraceLinkEvaluationSadCodeDirectIT {
     protected static final Logger logger = LoggerFactory.getLogger(TraceLinkEvaluationIT.class);
 
-    protected static final String OUTPUT = "src/test/resources/testout";
+    protected static final String OUTPUT = "target/testout";
 
     protected static final String LOGGING_ARDOCO_CORE = "org.slf4j.simpleLogger.log.edu.kit.kastel.mcse.ardoco.core";
 


### PR DESCRIPTION
This PR removes the output dependencies between multiple test cases and thereby hopefully fixes the parallel build issues.

In detail this PR defines multiple disjunct output directories. Before, the output directory was shared and automatically cleaned up by AfterAll or BeforeAll methods. Thus it was possible that a Test removes a file during another test writes into it.